### PR TITLE
Add P3 task plans for remaining git tools

### DIFF
--- a/docs/tasks/P3-001-git-diff.md
+++ b/docs/tasks/P3-001-git-diff.md
@@ -1,0 +1,110 @@
+# P3-001: GitDiff Tool
+
+**Status:** Not started
+**Depends on:** P2-004 (git tools), P2-005 (sandbox/resolve)
+**Estimated scope:** New macro + tool publication
+
+## Motivation
+
+`git diff` accounts for 708 bash calls (4.2% of all bash) in the conversation
+analysis. During the P2-004 review/merge session, diff was the single most
+frequent operation — checking PR diffs, comparing branches, viewing staged
+changes. It's the highest-value missing git read tool.
+
+duck_tails provides `read_git_diff(uri1, uri2)` which returns unified diff text
+between two git URIs, and `diff_text(a, b)` / `text_diff_lines(diff)` for
+structured line-level output. The building blocks exist but need a usable
+macro and MCP tool wrapper.
+
+## Design Considerations
+
+### What callers actually need
+
+From the session, these were the real queries:
+
+1. **`git diff rev1..rev2` (branch comparison)** — "What changed between main
+   and this branch?" Used before PRs, during reviews.
+2. **`git diff --stat`** — "Which files changed and how much?" The summary view.
+3. **`git diff -- file`** — "Show me the diff for this specific file."
+
+Working tree diffs (`git diff` with no args, `git diff --staged`) are less
+useful in MCP context because the LLM rarely has uncommitted changes of its
+own to inspect — it usually wants to compare commits or branches.
+
+### Proposed approach
+
+Two-level output: a **file-level summary** (like `--stat`) by default, with
+an optional `file_path` parameter to drill into a specific file's line-level
+diff. This avoids dumping massive unified diffs for multi-file changes.
+
+**File-level summary** uses `git_tree` comparison (no new extension functions
+needed):
+
+```sql
+-- Compare trees at two revisions to find changed files
+SELECT
+    COALESCE(a.file_path, b.file_path) AS file_path,
+    CASE
+        WHEN a.file_path IS NULL THEN 'added'
+        WHEN b.file_path IS NULL THEN 'deleted'
+        ELSE 'modified'
+    END AS status,
+    a.size_bytes AS old_size,
+    b.size_bytes AS new_size
+FROM git_tree(repo, from_rev) a
+FULL OUTER JOIN git_tree(repo, to_rev) b
+    ON a.file_path = b.file_path
+WHERE a.file_path IS NULL
+   OR b.file_path IS NULL
+   OR a.size_bytes != b.size_bytes
+```
+
+**File-level diff** uses `read_git_diff` + `text_diff_lines`:
+
+```sql
+-- Line-level diff for a specific file between two revisions
+SELECT * FROM text_diff_lines(
+    (SELECT diff_text FROM read_git_diff(
+        git_uri(repo, file, from_rev),
+        git_uri(repo, file, to_rev)
+    ))
+)
+```
+
+### Open questions
+
+- Should the file summary compare by content hash rather than size? Two files
+  can have the same size but different content. `git_tree` doesn't expose the
+  blob hash, so this may require `read_git_diff` per file (expensive for large
+  repos). Alternatively, accept the false-negative rate as a tradeoff.
+- Should there be a `context` parameter (like `git diff -U3`) for the
+  line-level view? `text_diff_lines` may not support this.
+- The `read_git_diff` function returns an error when given directory paths
+  rather than file paths. Need to verify behavior with binary files.
+
+## Tools
+
+| Tool | Required Params | Optional Params | Maps To |
+|------|----------------|-----------------|---------|
+| GitDiff | from_rev, to_rev | file_path, path | `file_changes(from, to, repo)` or `file_diff(file, from, to, repo)` |
+
+Alternatively, this could be two tools:
+- `GitDiffSummary` (file-level, `--stat` equivalent)
+- `GitDiffFile` (line-level, single file)
+
+## Files
+
+| File | Action | Description |
+|------|--------|-------------|
+| `sql/repo.sql` | Update | Add `file_changes()` and/or `file_diff()` macros |
+| `sql/tools/git.sql` | Update | Add `mcp_publish_tool()` call(s) |
+| `tests/test_repo.py` | Update | Macro-level tests for new macros |
+| `tests/test_mcp_server.py` | Update | MCP tool tests |
+
+## Acceptance Criteria
+
+- `TestGitDiff` tests pass in `test_mcp_server.py`:
+  - Returns changed files between two revisions
+  - Shows add/delete/modify status correctly
+  - Line-level diff for a specific file shows additions and removals
+- Existing tests unaffected

--- a/docs/tasks/P3-002-git-status.md
+++ b/docs/tasks/P3-002-git-status.md
@@ -1,0 +1,85 @@
+# P3-002: GitStatus Tool
+
+**Status:** Not started
+**Depends on:** P2-004 (git tools), P2-005 (sandbox/resolve)
+**Estimated scope:** New macro + tool publication. Requires investigation — duck_tails has no `git_status` function.
+
+## Motivation
+
+`git status` accounts for 775 bash calls — the single most frequent git read
+operation in the conversation analysis. It's the first thing an LLM checks
+before commits, merges, and conflict resolution.
+
+During the P2-004 session, `git status` was used to:
+- Check for uncommitted changes before merging
+- Verify merge conflict state
+- Confirm clean working tree after conflict resolution
+- Check branch tracking state
+
+## Design Considerations
+
+### duck_tails gap
+
+Unlike `git_diff`, there is **no `git_status` function** in duck_tails.
+The extension provides tree/log/branch/tag queries against the git object
+database, but working tree status requires comparing the index against both
+HEAD and the working directory — a fundamentally different operation.
+
+### Possible approaches
+
+1. **Shell out via DuckDB** — Use a DuckDB macro that calls `git status
+   --porcelain` via a system command. DuckDB doesn't have a built-in
+   shell-out mechanism, so this would need an extension or workaround.
+
+2. **Synthesize from git_tree** — Compare `git_tree('.', 'HEAD')` against
+   the filesystem (via `glob` or `read_lines`) to detect modifications.
+   This gives tracked-file changes but misses staged vs unstaged distinction
+   and untracked files.
+
+3. **Upstream contribution** — Add `git_status()` to duck_tails. This is
+   probably the right long-term answer since libgit2 (which duck_tails
+   likely uses) has `git_status_list_new()`.
+
+4. **Defer** — Accept that `git status` stays as a bash call. It's fast,
+   well-understood, and the output is small. The MCP benefit is primarily
+   about structured output, not permission reduction.
+
+### Recommendation
+
+Start with approach 3 (upstream) if feasible. If not, approach 4 (defer) is
+acceptable — `git status` is a single quick bash call, not a multi-step
+pipeline. The 775 calls are high-frequency but low-cost individually.
+
+File an issue on duck_tails requesting `git_status(repo)` that returns:
+```
+| file_path | index_status | worktree_status |
+```
+
+Where status values are: new, modified, deleted, renamed, untracked, ignored.
+
+## Tools
+
+| Tool | Required Params | Optional Params | Maps To |
+|------|----------------|-----------------|---------|
+| GitStatus | — | path | `working_tree_status(repo)` (pending upstream) |
+
+## Files
+
+| File | Action | Description |
+|------|--------|-------------|
+| `sql/repo.sql` | Update | Add `working_tree_status()` macro (once upstream exists) |
+| `sql/tools/git.sql` | Update | Add `mcp_publish_tool()` call |
+| `tests/test_repo.py` | Update | Macro-level tests |
+| `tests/test_mcp_server.py` | Update | MCP tool tests |
+
+## Acceptance Criteria
+
+- `TestGitStatus` tests pass:
+  - Shows modified files in working tree
+  - Shows untracked files
+  - Returns empty result on clean working tree
+- Existing tests unaffected
+
+## Blockers
+
+- Requires `git_status()` in duck_tails, or a decision to use a workaround approach.

--- a/docs/tasks/P3-003-git-show.md
+++ b/docs/tasks/P3-003-git-show.md
@@ -1,0 +1,59 @@
+# P3-003: GitShow Tool (File at Version)
+
+**Status:** Not started
+**Depends on:** P2-004 (git tools), P2-005 (sandbox/resolve)
+**Estimated scope:** Tool publication only — macro already exists
+
+## Motivation
+
+`git show` accounts for 91 bash calls in the conversation analysis. The
+macro `file_at_version(file, rev, repo)` already exists in `repo.sql` and
+wraps `git_read(git_uri(...))`. It just needs an MCP tool publication.
+
+During the P2-004 session, reading files at specific revisions was needed to
+compare the prior state of `test_mcp_server.py` on main vs the feature branch
+before resolving conflicts. The `ReadLines` tool already supports a `commit`
+parameter for this, but `GitShow` would be the explicit git-native equivalent
+with different output shape (includes metadata like file_path, ref, size).
+
+## Design Considerations
+
+### Overlap with ReadLines
+
+`ReadLines` with `commit` parameter already does `git show rev:path`
+semantically. The difference:
+
+- **ReadLines(file_path, commit)**: Returns line-numbered content in a markdown
+  table. Designed for code reading with context/match filtering.
+- **GitShow(file, rev)**: Returns raw content with metadata (path, ref, size).
+  Designed for git inspection — "what did this file look like at v1.0?"
+
+The question is whether both are needed or whether ReadLines subsumes this.
+
+### Recommendation
+
+Publish as a tool anyway — it's a single `mcp_publish_tool()` call with zero
+new macro work. Let usage data determine whether it earns its keep. If it's
+redundant with ReadLines+commit, it can be removed later.
+
+## Tools
+
+| Tool | Required Params | Optional Params | Maps To |
+|------|----------------|-----------------|---------|
+| GitShow | file, rev | path | `file_at_version(file, rev, repo)` |
+
+## Files
+
+| File | Action | Description |
+|------|--------|-------------|
+| `sql/repo.sql` | No change | `file_at_version` macro already exists |
+| `sql/tools/git.sql` | Update | Add `mcp_publish_tool()` call |
+| `tests/test_mcp_server.py` | Update | MCP tool test |
+
+## Acceptance Criteria
+
+- `TestGitShow` test passes:
+  - Returns file content at HEAD
+  - Returns file content at a prior revision
+  - Returns metadata (file_path, ref, size_bytes)
+- Existing tests unaffected

--- a/docs/tasks/P3-004-git-tags.md
+++ b/docs/tasks/P3-004-git-tags.md
@@ -1,0 +1,53 @@
+# P3-004: GitTags Tool
+
+**Status:** Not started
+**Depends on:** P2-004 (git tools), P2-005 (sandbox/resolve)
+**Estimated scope:** Tool publication only — macro already exists
+
+## Motivation
+
+`git tag` accounts for 175 bash calls in the conversation analysis. The
+macro `tag_list(repo)` already exists in `repo.sql` and wraps `git_tags()`.
+It just needs an MCP tool publication.
+
+Tags are used for release management, version checking, and understanding
+project history. The `tag_list` macro returns structured tag data including
+tagger, date, message, and whether the tag is annotated.
+
+## Tools
+
+| Tool | Required Params | Optional Params | Maps To |
+|------|----------------|-----------------|---------|
+| GitTags | — | — | `tag_list(repo)` |
+
+## Files
+
+| File | Action | Description |
+|------|--------|-------------|
+| `sql/repo.sql` | No change | `tag_list` macro already exists |
+| `sql/tools/git.sql` | Update | Add `mcp_publish_tool()` call |
+| `tests/test_mcp_server.py` | Update | MCP tool test |
+
+## Implementation
+
+Same pattern as `GitBranches` — no parameters, hardcode `sextant_root`
+at publish time:
+
+```sql
+SELECT mcp_publish_tool(
+    'GitTags',
+    'List all tags with metadata. Shows tag name, commit hash, tagger, date, and whether annotated.',
+    'SELECT * FROM tag_list(''' || getvariable('sextant_root') || ''')',
+    '{}',
+    '[]',
+    'markdown'
+);
+```
+
+## Acceptance Criteria
+
+- `TestGitTags` test passes:
+  - Returns tags (if repo has any) or empty result
+- Existing tests unaffected
+- Note: this repo may not have tags yet, so the test may need to
+  create one in a fixture or just verify the tool executes without error


### PR DESCRIPTION
## Summary
- Add 4 task plans for the next phase of git tool development (P3-001 through P3-004)
- Plans identified from hands-on experience during P2-004 implementation and conversation analysis data

## Plans

| Plan | Tool | Bash Calls | Effort |
|------|------|-----------|--------|
| P3-001 | GitDiff — compare revisions | 708 | New macro + tool |
| P3-002 | GitStatus — working tree state | 775 | Blocked (no duck_tails function) |
| P3-003 | GitShow — file at version | 91 | Tool publication only |
| P3-004 | GitTags — list tags | 175 | Tool publication only |

Corresponding issues: #6, #7, #8, #9

## Test plan
- Docs only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)