### PR TITLE
Rename project: Source Sextant → Fledgling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Source Sextant: Project Conventions
+# Fledgling: Project Conventions
 
 ## Architecture
 
@@ -9,7 +9,7 @@ SQL macros first, MCP tools second. Every tool is backed by a reusable macro in 
 ### File header
 
 ```sql
--- Source Sextant: <Tier Name> Macros (<extension_name>)
+-- Fledgling: <Tier Name> Macros (<extension_name>)
 --
 -- Brief description of what this tier provides.
 ```
@@ -42,7 +42,7 @@ CREATE OR REPLACE MACRO macro_name(...) AS TABLE
 ### File header
 
 ```sql
--- Source Sextant: <Tier Name> Tool Publications
+-- Fledgling: <Tier Name> Tool Publications
 --
 -- MCP tool publications for <description>.
 -- Wraps macros from sql/<tier>.sql.
@@ -88,13 +88,13 @@ resolve($file_path)
 resolve($file_pattern)
 
 -- Optional path with fallback to project root
-COALESCE(resolve(NULLIF($path, ''null'')), '<sextant_root>')
+COALESCE(resolve(NULLIF($path, ''null'')), '<session_root>')
 ```
 
-Git tool paths embed `sextant_root` at publish time because `getvariable()` is not available in the MCP tool execution context:
+Git tool paths embed `session_root` at publish time because `getvariable()` is not available in the MCP tool execution context:
 
 ```sql
-'... ''' || getvariable('sextant_root') || ''' ...'
+'... ''' || getvariable('session_root') || ''' ...'
 ```
 
 ## DuckDB Quirks
@@ -145,7 +145,7 @@ These are hard-won lessons. Don't remove workarounds without verifying the upstr
 ## File Organization
 
 ```
-init-source-sextant.sql   Entry point for duckdb -init
+init-fledgling.sql        Entry point for duckdb -init
 sql/
   <tier>.sql              Macro definitions (one file per tier)
   sandbox.sql             resolve() macro + sandbox setup
@@ -169,7 +169,7 @@ docs/
 3. LOAD sitting_duck
 4. LOAD markdown
 5. LOAD duck_tails
-6. SET VARIABLE sextant_root = ...
+6. SET VARIABLE session_root = ...
 7. Load sandbox.sql                         (resolve() macro)
 8. Load macro files (source, code, docs, repo)
 9. Load tool publication files

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Source Sextant
+# Fledgling
 
 MCP tools that help AI agents get their bearings in a codebase — structured retrieval over code, git, docs, and conversations, powered by DuckDB.
 
@@ -8,9 +8,9 @@ AI coding agents retrieve data through shell commands. To find where `parse_conf
 
 Every one of these steps produces unstructured text the agent has to parse before it can reason about the answer. Tokens spent on text parsing are tokens not spent on solving your problem.
 
-## What Source Sextant Does
+## What Fledgling Does
 
-Source Sextant replaces shell-command-and-parse with purpose-built MCP tools that return structured results. Each tool is backed by a DuckDB community extension that understands the data format natively:
+Fledgling replaces shell-command-and-parse with purpose-built MCP tools that return structured results. Each tool is backed by a DuckDB community extension that understands the data format natively:
 
 | Capability | Replaces | Extension |
 |-----------|----------|-----------|
@@ -50,14 +50,14 @@ Returns structured rows with hash, author, date, and message.
 ```sql
 SELECT * FROM bash_commands() WHERE replaceable_by IS NOT NULL;
 ```
-Analyzes an agent's own bash usage to find commands Source Sextant could replace.
+Analyzes an agent's own bash usage to find commands Fledgling could replace.
 
 ## How It Works
 
-Source Sextant is a DuckDB init script. It loads extensions, defines SQL macros, publishes them as MCP tools, and starts a server:
+Fledgling is a DuckDB init script. It loads extensions, defines SQL macros, publishes them as MCP tools, and starts a server:
 
 ```
-duckdb -init init-source-sextant.sql
+duckdb -init init-fledgling.sql
 ```
 
 Configure it in Claude Code's `settings.json`:
@@ -65,15 +65,15 @@ Configure it in Claude Code's `settings.json`:
 ```json
 {
   "mcpServers": {
-    "source_sextant": {
+    "fledgling": {
       "command": "duckdb",
-      "args": ["-init", "/path/to/init-source-sextant.sql"]
+      "args": ["-init", "/path/to/init-fledgling.sql"]
     }
   }
 }
 ```
 
-Everything is read-only. Source Sextant retrieves and analyzes — it never modifies files or makes git writes.
+Everything is read-only. Fledgling retrieves and analyzes — it never modifies files or makes git writes.
 
 ## Status
 

--- a/config/claude-code.example.json
+++ b/config/claude-code.example.json
@@ -1,11 +1,11 @@
 {
   "mcpServers": {
-    "source_sextant": {
+    "fledgling": {
       "command": "duckdb",
-      "args": ["-init", "init-source-sextant.sql"],
-      "cwd": "/absolute/path/to/source-sextant",
+      "args": ["-init", "init-fledgling.sql"],
+      "cwd": "/absolute/path/to/fledgling",
       "env": {
-        "SEXTANT_PROJECT_ROOT": "/path/to/your/project"
+        "FLEDGLING_ROOT": "/path/to/your/project"
       }
     }
   }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,11 +12,11 @@
 
 ## Installation
 
-Source Sextant is currently a collection of SQL macro files. To use it:
+Fledgling is currently a collection of SQL macro files. To use it:
 
 ```bash
 git clone https://github.com/teaguesterling/source-sextant.git
-cd source-sextant
+cd fledgling
 ```
 
 ## Usage with DuckDB
@@ -58,16 +58,16 @@ SELECT * FROM recent_changes(10);
 ## MCP Server Setup
 
 !!! note
-    8 of 11 MCP tools are published and tested (code, docs, git). The `init-source-sextant.sql` entry point and example config are still pending (P2-005).
+    8 of 11 MCP tools are published and tested (code, docs, git). The `init-fledgling.sql` entry point and example config are still pending (P2-005).
 
 Once the init script is ready, add to your Claude Code settings:
 
 ```json
 {
   "mcpServers": {
-    "source_sextant": {
+    "fledgling": {
       "command": "duckdb",
-      "args": ["-init", "/path/to/source-sextant/init-source-sextant.sql"]
+      "args": ["-init", "/path/to/fledgling/init-fledgling.sql"]
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
-# Source Sextant
+# Fledgling
 
 **MCP tools that help AI agents get their bearings in a codebase — unified SQL views over code, git, docs, and conversations, powered by DuckDB.**
 
-## What is Source Sextant?
+## What is Fledgling?
 
-Source Sextant is a DuckDB-powered [MCP](https://modelcontextprotocol.io/) server that gives AI agents navigational awareness of development environments. Instead of agents running bash commands (`cat`, `grep`, `git log`) that produce unstructured text, Source Sextant provides structured, composable SQL macros exposed as MCP tools.
+Fledgling is a DuckDB-powered [MCP](https://modelcontextprotocol.io/) server that gives AI agents navigational awareness of development environments. Instead of agents running bash commands (`cat`, `grep`, `git log`) that produce unstructured text, Fledgling provides structured, composable SQL macros exposed as MCP tools.
 
 It composes several DuckDB community extensions into a single queryable surface:
 
@@ -18,7 +18,7 @@ It composes several DuckDB community extensions into a single queryable surface:
 
 ## Why?
 
-AI coding assistants spend significant tokens on low-level bash commands for tasks that are fundamentally *data retrieval*. Source Sextant replaces those with structured, composable queries:
+AI coding assistants spend significant tokens on low-level bash commands for tasks that are fundamentally *data retrieval*. Fledgling replaces those with structured, composable queries:
 
 ```sql
 -- Instead of: cat src/parser.py | sed -n '40,50p'

--- a/docs/planning/NEXT_STEPS.md
+++ b/docs/planning/NEXT_STEPS.md
@@ -1,4 +1,4 @@
-# Source Sextant: Next Steps
+# Fledgling: Next Steps
 
 **Last session**: 2026-02-26 (afternoon)
 **State**: 138 passing tests (13 expected failures pending P2-001), MCP tools published for code/docs/git
@@ -6,7 +6,7 @@
 ## What Exists
 
 ```
-source-sextant/
+fledgling/
   sql/
     source.sql          ✅ 4 macros, 13 tests
     code.sql            ✅ 4 macros, 13 tests
@@ -76,7 +76,7 @@ across 9 servers (aidr, blq, duckdb_mcp_test, lq, mess, Notion, context7,
 playwright, venv_blq).
 
 ### Project rename (2026-02-26 morning)
-Renamed from `duck_nest` to `source-sextant`.
+Renamed from `duck_nest` to `source-sextant`, then to `fledgling`.
 
 ### Documentation infrastructure (2026-02-26 morning)
 ReadTheDocs + mkdocs-material, macro reference pages, getting started guide.
@@ -97,7 +97,7 @@ See `docs/tasks/P2-001-files-tools.md` for full spec.
 
 - ✅ `sql/sandbox.sql` — path resolution and lockdown
 - ✅ `tests/conftest.py` — MCP server fixture with memory transport
-- ⚠️ `init-source-sextant.sql` — entry point for `duckdb -init` (not yet created)
+- ⚠️ `init-fledgling.sql` — entry point for `duckdb -init` (not yet created)
 - ⚠️ `config/claude-code.example.json` — example MCP config (not yet created)
 
 See `docs/tasks/P2-005-init-and-config.md` for full spec.
@@ -112,7 +112,7 @@ need to decide: auto-load from `~/.claude/projects/` on startup, or expose
 ## Phase 3: Polish and Iterate
 
 ### Trim settings.json bash whitelist
-Once source_sextant is running as MCP, start removing bash entries covered
+Once fledgling is running as MCP, start removing bash entries covered
 by MCP tools. The conversation analysis showed which ones:
 - `cat`, `head`, `tail` → `read_source`
 - `grep`, `find` → `find_definitions` / Grep tool
@@ -125,7 +125,7 @@ The conversation schema design doc has a blog outline. The data is compelling:
 tooling decisions.
 
 ### Per-project configuration
-Currently source_sextant is global. Consider how project-specific tools
+Currently fledgling is global. Consider how project-specific tools
 would work.
 
 ## Upstream Issues Filed
@@ -142,6 +142,6 @@ would work.
 
 ## Future: Safe Git MCP Server (Separate Project)
 
-Out of scope for source_sextant (which is read-only), but the conversation
+Out of scope for fledgling (which is read-only), but the conversation
 analysis showed 2,810 git write operations (16.5% of all bash). A
 separate server with safety guardrails.

--- a/docs/tasks/P2-001-files-tools.md
+++ b/docs/tasks/P2-001-files-tools.md
@@ -29,7 +29,7 @@ in `source.sql` alongside the tool publications.
 
 All tool SQL templates must use `resolve($file_path)` to convert relative
 paths to absolute (required for DuckDB sandbox, see P2-005). The `resolve()`
-macro prepends `sextant_root` for relative paths, passes absolute paths through.
+macro prepends `session_root` for relative paths, passes absolute paths through.
 
 ```sql
 -- In tool SQL templates:

--- a/docs/tasks/P2-004-git-tools.md
+++ b/docs/tasks/P2-004-git-tools.md
@@ -26,18 +26,18 @@ are user-facing, macro names follow SQL convention).
 
 ## Path Resolution
 
-Git tools use `sextant_root` as the default repo path (instead of `'.'`)
+Git tools use `session_root` as the default repo path (instead of `'.'`)
 so they work correctly under the sandbox. The `resolve()` macro is used
 for the optional `path` param on GitChanges.
 
 ```sql
--- GitBranches: no params, uses sextant_root directly
-SELECT * FROM branch_list(getvariable('sextant_root'))
+-- GitBranches: no params, uses session_root directly
+SELECT * FROM branch_list(getvariable('session_root'))
 
--- GitChanges: optional path defaults to sextant_root
+-- GitChanges: optional path defaults to session_root
 SELECT * FROM recent_changes(
     COALESCE(TRY_CAST(NULLIF($count, 'null') AS INT), 10),
-    COALESCE(resolve(NULLIF($path, 'null')), getvariable('sextant_root'))
+    COALESCE(resolve(NULLIF($path, 'null')), getvariable('session_root'))
 )
 ```
 

--- a/docs/tasks/P2-005-init-and-config.md
+++ b/docs/tasks/P2-005-init-and-config.md
@@ -15,8 +15,8 @@ tool files, and provide an example Claude Code configuration.
 
 | File | Action | Description |
 |------|--------|-------------|
-| `sql/sandbox.sql` | Create | `sextant_root` variable, `resolve()` macro, lockdown |
-| `init-source-sextant.sql` | Create | Entry point for `duckdb -init` |
+| `sql/sandbox.sql` | Create | `session_root` variable, `resolve()` macro, lockdown |
+| `init-fledgling.sql` | Create | Entry point for `duckdb -init` |
 | `config/claude-code.example.json` | Create | Example MCP server config |
 | `tests/conftest.py` | Update | Load modular tool files + sandbox setup |
 
@@ -32,8 +32,8 @@ MCP clients send relative paths.
 ### Solution
 
 1. **Before lockdown**: capture CWD into a variable via `getenv('PWD')`
-2. **`resolve(path)`**: scalar macro that prepends `sextant_root` for relative paths
-3. **`allowed_directories`**: set from `sextant_root` plus user-configurable extras
+2. **`resolve(path)`**: scalar macro that prepends `session_root` for relative paths
+3. **`allowed_directories`**: set from `session_root` plus user-configurable extras
 4. **Lockdown**: `enable_external_access = false`, `lock_configuration = true`
 5. **All tool SQL templates** use `resolve($file_path)` instead of bare `$file_path`
 
@@ -41,14 +41,14 @@ MCP clients send relative paths.
 
 ```sql
 -- Capture project root before lockdown.
--- Override sextant_root before loading this file to use a custom root.
-SET VARIABLE sextant_root = COALESCE(
-    getvariable('sextant_root'),
+-- Override session_root before loading this file to use a custom root.
+SET VARIABLE session_root = COALESCE(
+    getvariable('session_root'),
     getenv('PWD')
 );
 
 -- Additional allowed directories (set before loading this file).
--- Example: SET VARIABLE sextant_extra_dirs = ['/data/shared', '/opt/models'];
+-- Example: SET VARIABLE extra_dirs = ['/data/shared', '/opt/models'];
 -- Defaults to empty list if not set.
 
 -- Resolve relative paths against project root.
@@ -56,14 +56,14 @@ SET VARIABLE sextant_root = COALESCE(
 -- When duckdb#21102 is fixed, this can become a no-op.
 CREATE OR REPLACE MACRO resolve(p) AS
     CASE WHEN p[1] = '/' THEN p
-         ELSE getvariable('sextant_root') || '/' || p
+         ELSE getvariable('session_root') || '/' || p
     END;
 
 -- Lock down filesystem access.
--- sextant_root is always allowed; extras are appended if set.
+-- session_root is always allowed; extras are appended if set.
 SET allowed_directories = list_concat(
-    [getvariable('sextant_root')],
-    COALESCE(getvariable('sextant_extra_dirs'), [])
+    [getvariable('session_root')],
+    COALESCE(getvariable('extra_dirs'), [])
 );
 SET enable_external_access = false;
 SET lock_configuration = true;
@@ -73,8 +73,8 @@ SET lock_configuration = true;
 
 ```sql
 -- Optional: override root and/or add extra dirs before sandbox.sql
--- SET VARIABLE sextant_root = '/path/to/project';
--- SET VARIABLE sextant_extra_dirs = ['/data/shared'];
+-- SET VARIABLE session_root = '/path/to/project';
+-- SET VARIABLE extra_dirs = ['/data/shared'];
 
 .read sql/sandbox.sql
 ```
@@ -91,7 +91,7 @@ SELECT * FROM read_markdown_sections(resolve($file_pattern), ...)
 ### What's sandboxed
 
 - All `read_lines`, `read_ast`, `read_markdown_*`, `glob()` calls are restricted
-  to `sextant_root` (+ any `sextant_extra_dirs`)
+  to `session_root` (+ any `extra_dirs`)
 - Path traversal (`../../../etc/passwd`) is blocked by DuckDB
 - `getenv()` is disabled after lockdown
 - Configuration cannot be changed after lockdown
@@ -101,7 +101,7 @@ SELECT * FROM read_markdown_sections(resolve($file_pattern), ...)
 - Git operations via `duck_tails` (operate on the repo, which is the project root)
 - The `query` built-in tool (full SQL access, but filesystem is still locked)
 
-## init-source-sextant.sql
+## init-fledgling.sql
 
 Following duckdb_mcp example-06 pattern. Uses `.read` for modularity —
 any tool category can be disabled by commenting out its line.
@@ -123,8 +123,8 @@ LOAD duck_tails;
 DROP MACRO TABLE IF EXISTS read_lines;
 
 -- Optional: set project root and extra allowed dirs before sandbox
--- SET VARIABLE sextant_root = '/custom/project/path';
--- SET VARIABLE sextant_extra_dirs = ['/data/shared'];
+-- SET VARIABLE session_root = '/custom/project/path';
+-- SET VARIABLE extra_dirs = ['/data/shared'];
 
 -- Sandbox: capture root, create resolve(), lock filesystem
 .read sql/sandbox.sql
@@ -165,7 +165,7 @@ correct working directory or use absolute paths.
 ## Test Fixture Update
 
 The fixture mirrors the init script but uses memory transport and
-sets `sextant_root` to `PROJECT_ROOT` explicitly:
+sets `session_root` to `PROJECT_ROOT` explicitly:
 
 ```python
 @pytest.fixture(scope="session")
@@ -178,7 +178,7 @@ def mcp_server():
     con.execute("LOAD duck_tails")
     con.execute("DROP MACRO TABLE IF EXISTS read_lines")
     # Sandbox (set root before loading sandbox.sql)
-    con.execute(f"SET VARIABLE sextant_root = '{PROJECT_ROOT}'")
+    con.execute(f"SET VARIABLE session_root = '{PROJECT_ROOT}'")
     load_sql(con, "sandbox.sql")
     # Macros
     load_sql(con, "source.sql")
@@ -205,9 +205,9 @@ file should be structured so lockdown can be skipped for testing.
 ```json
 {
   "mcpServers": {
-    "source_sextant": {
+    "fledgling": {
       "command": "duckdb",
-      "args": ["-init", "/absolute/path/to/source-sextant/init-source-sextant.sql"],
+      "args": ["-init", "/absolute/path/to/fledgling/init-fledgling.sql"],
       "cwd": "/path/to/your/project"
     }
   }
@@ -215,13 +215,13 @@ file should be structured so lockdown can be skipped for testing.
 ```
 
 Goes in `~/.claude/settings.json` (global) or `.mcp.json` (per-project).
-CWD determines the project root (captured as `sextant_root`).
+CWD determines the project root (captured as `session_root`).
 
 ## Acceptance Criteria
 
 - All 27 MCP tests pass (requires P2-001 through P2-004 complete)
 - All 94 existing tests still pass
-- `duckdb -init init-source-sextant.sql` starts without errors (manual smoke test)
+- `duckdb -init init-fledgling.sql` starts without errors (manual smoke test)
 - Tools discoverable via `tools/list` JSON-RPC request
-- Files outside `sextant_root` cannot be read through tools (manual verification)
+- Files outside `session_root` cannot be read through tools (manual verification)
 - Path traversal attempts are blocked

--- a/docs/tasks/P3-004-git-tags.md
+++ b/docs/tasks/P3-004-git-tags.md
@@ -30,14 +30,14 @@ tagger, date, message, and whether the tag is annotated.
 
 ## Implementation
 
-Same pattern as `GitBranches` — no parameters, hardcode `sextant_root`
+Same pattern as `GitBranches` — no parameters, hardcode `session_root`
 at publish time:
 
 ```sql
 SELECT mcp_publish_tool(
     'GitTags',
     'List all tags with metadata. Shows tag name, commit hash, tagger, date, and whether annotated.',
-    'SELECT * FROM tag_list(''' || getvariable('sextant_root') || ''')',
+    'SELECT * FROM tag_list(''' || getvariable('session_root') || ''')',
     '{}',
     '[]',
     'markdown'

--- a/docs/vision/CONVERSATION_ANALYSIS.md
+++ b/docs/vision/CONVERSATION_ANALYSIS.md
@@ -1,4 +1,4 @@
-# Source Sextant: Conversation Log Analysis
+# Fledgling: Conversation Log Analysis
 
 **Date**: 2026-02-26
 **Method**: DuckDB `read_json_auto()` across all `~/.claude/projects/*/*.jsonl`
@@ -83,7 +83,7 @@ unstructured text, and can't compose with other tools.
 GitHub CLI is probably best left as bash — it's well-structured with
 `--json` flags and doesn't benefit much from a DuckDB layer.
 
-## Source Sextant Replacement Potential
+## Fledgling Replacement Potential
 
 | Replacement | Bash Calls Replaced | % of Bash | % of All Tools |
 |-------------|--------------------:|----------:|---------------:|
@@ -91,14 +91,14 @@ GitHub CLI is probably best left as bash — it's well-structured with
 | read_lines (file read) | 459 | 2.7% | 1.1% |
 | sitting_duck (code search) | 756 | 4.4% | 1.7% |
 | DuckDB SQL (text processing) | 98 | 0.6% | 0.2% |
-| **Total source_sextant** | **3,335** | **19.6%** | **7.7%** |
+| **Total fledgling** | **3,335** | **19.6%** | **7.7%** |
 | safe-git (future, git write) | 2,810 | 16.5% | 6.5% |
 | **Total if both built** | **6,145** | **36.1%** | **14.2%** |
 | Not replaceable | 10,864 | 63.9% | 25.1% |
 
 ### What This Means
 
-If source_sextant existed today, it would replace **~3,300 bash calls** (20% of
+If fledgling existed today, it would replace **~3,300 bash calls** (20% of
 all bash usage). Combined with a future safe-git server, that rises to
 **~6,100 calls** (36% of bash). The remaining 64% is build tools, runtime
 execution, GitHub CLI, and misc filesystem operations — things that genuinely
@@ -155,7 +155,7 @@ The JSONL records have a rich, queryable schema including:
 | P90 user msgs/session | 772 |
 | Max user msgs/session | 5,063 |
 
-## Implications for Source Sextant Design
+## Implications for Fledgling Design
 
 ### 1. Conversation Analysis is Viable and Valuable
 
@@ -179,9 +179,9 @@ SELECT block->>'name' as tool, block->'input' as params
 FROM blocks WHERE block->>'type' = 'tool_use'
 ```
 
-This should be pre-materialized as a macro or view in source_sextant.
+This should be pre-materialized as a macro or view in fledgling.
 
-### 3. Priority Order for Source Sextant Tools
+### 3. Priority Order for Fledgling Tools
 
 Based on actual usage data:
 

--- a/docs/vision/CONVERSATION_SCHEMA_DESIGN.md
+++ b/docs/vision/CONVERSATION_SCHEMA_DESIGN.md
@@ -164,7 +164,7 @@ tool call, extracts:
 - `leading_command`: First token (git, ls, python, ...)
 - `git_subcommand`: For git commands, the subcommand (add, diff, push, ...)
 - `category`: High-level classification (git_read, git_write, build_tools, ...)
-- `replaceable_by`: Which source_sextant tool could handle this (duck_tails,
+- `replaceable_by`: Which fledgling tool could handle this (duck_tails,
   sitting_duck, read_lines, duckdb_sql, or NULL)
 
 **`session_summary`** -- The dashboard view. Joins sessions with aggregated
@@ -196,7 +196,7 @@ GROUP BY tool_name
 ORDER BY total DESC;
 ```
 
-### What bash commands could source_sextant replace?
+### What bash commands could fledgling replace?
 
 ```sql
 SELECT
@@ -376,7 +376,7 @@ than "file_search".
    drift. These are genuinely useful warnings for anyone working with
    similar data.
 
-9. **What's Next** -- Tease source_sextant: structured tools replacing bash,
+9. **What's Next** -- Tease fledgling: structured tools replacing bash,
    conversation analysis as a live MCP capability.
 
 ### Key Visuals:

--- a/docs/vision/PRODUCT_SPEC.md
+++ b/docs/vision/PRODUCT_SPEC.md
@@ -1,17 +1,17 @@
-# Source Sextant: Product Specification
+# Fledgling: Product Specification
 
 **Version**: 0.1 (Draft)
 **Status**: Alpha — Phase 2 (MCP tool publications) in progress
 
-## What Is Source Sextant?
+## What Is Fledgling?
 
-Source Sextant is a DuckDB-powered MCP server that unifies development intelligence tools
+Fledgling is a DuckDB-powered MCP server that unifies development intelligence tools
 into a single queryable surface. It brings together existing DuckDB extensions —
 `sitting_duck` (code semantics), `duck_tails` (git state), `read_lines` (file retrieval),
 `duckdb_markdown` (document structure) — and adds conversation analysis capabilities,
 all exposed as purpose-built MCP tools via `duckdb_mcp`.
 
-The name: a sextant helps navigators get their bearings — this tool helps AI agents get their bearings in source code.
+The name: a fledgling learning to navigate — this tool helps AI agents get their bearings in source code.
 
 ## Problem Statement
 
@@ -35,16 +35,16 @@ each problem with structured, queryable results.
 
 ## Architecture
 
-Source Sextant is **not a new codebase** in the traditional sense. It is:
+Fledgling is **not a new codebase** in the traditional sense. It is:
 
-1. A **DuckDB init script** (`init-source-sextant.sql`) that loads extensions, defines
+1. A **DuckDB init script** (`init-fledgling.sql`) that loads extensions, defines
    macros, publishes MCP tools, and starts the server
 2. A set of **SQL macro files** organized by concern
 3. **Configuration** for Claude Code (`settings.json` / `.mcp.json` integration)
 
 ```
-source_sextant/
-  init-source-sextant.sql          # Entry point: load, configure, publish, serve
+fledgling/
+  init-fledgling.sql          # Entry point: load, configure, publish, serve
   sql/
     source.sql                # read_lines macros + tools
     code.sql                  # sitting_duck macros + tools
@@ -71,7 +71,7 @@ source_sextant/
 ### How It Works
 
 ```sql
--- init-source-sextant.sql (conceptual)
+-- init-fledgling.sql (conceptual)
 LOAD duckdb_mcp;
 LOAD read_lines;
 LOAD sitting_duck;
@@ -97,9 +97,9 @@ Claude Code configuration:
 ```json
 {
   "mcpServers": {
-    "source_sextant": {
+    "fledgling": {
       "command": "duckdb",
-      "args": ["-init", "/path/to/source_sextant/init-source-sextant.sql"]
+      "args": ["-init", "/path/to/fledgling/init-fledgling.sql"]
     }
   }
 }
@@ -394,7 +394,7 @@ that the agent can process without parsing.
 
 ### 4. Read-only by default
 
-Source Sextant is a *retrieval* server. It reads files, parses code, queries git
+Fledgling is a *retrieval* server. It reads files, parses code, queries git
 history, and analyzes conversations. It does not modify anything.
 `enable_execute_tool` is `false`. Git write operations (commit, push) are
 explicitly out of scope — they belong in a separate "safe-git" server with
@@ -425,20 +425,20 @@ The server should work with sensible defaults when launched from a project
 directory. Extensions auto-detect languages, git discovers the repo,
 conversation logs are found from `~/.claude/`.
 
-## What Source Sextant Is NOT
+## What Fledgling Is NOT
 
 - **Not a replacement for aidr**: aidr is a persistent analytical workspace with
-  cognitive tracking. Source Sextant is a read-only retrieval layer.
+  cognitive tracking. Fledgling is a read-only retrieval layer.
 - **Not a replacement for blq**: blq captures and analyzes build/test output with
-  duck_hunt parsing. Source Sextant doesn't run commands.
+  duck_hunt parsing. Fledgling doesn't run commands.
 - **Not a git write tool**: No commits, no pushes, no branch operations. That's
   a separate concern with different security requirements.
-- **Not a new extension**: Source Sextant composes existing extensions. It adds SQL
+- **Not a new extension**: Fledgling composes existing extensions. It adds SQL
   macros and MCP tool definitions, not C++ code.
 
 ## Impact on settings.json
 
-With Source Sextant operational, these bash whitelist entries become unnecessary:
+With Fledgling operational, these bash whitelist entries become unnecessary:
 
 ```
 REMOVE (replaced by read_source / read_context):
@@ -454,7 +454,7 @@ REMOVE (replaced by DuckDB SQL via query tool):
   Bash(wc *), Bash(sort *), Bash(uniq *), Bash(cut *), Bash(tr *),
   Bash(awk *), Bash(sed *)
 
-KEEP (no Source Sextant equivalent):
+KEEP (no Fledgling equivalent):
   Bash(ls *), Bash(mkdir *), Bash(tree *), Bash(stat *), Bash(file *)
   Bash(realpath *), Bash(basename *), Bash(dirname *)
   Bash(diff *), Bash(echo *), Bash(printf *), Bash(pwd), Bash(which *)
@@ -473,7 +473,7 @@ Net reduction: ~20 bash whitelist entries replaced by structured MCP tools.
 2. **Conversation log format**: What's the exact schema of the `.jsonl` files in
    `~/.claude/projects/`? Need to explore before finalizing conversation tools.
 
-3. **Per-project vs global**: Should Source Sextant run as a global MCP server (one
+3. **Per-project vs global**: Should Fledgling run as a global MCP server (one
    instance serving all projects) or per-project? Git and code analysis are
    inherently project-scoped, but conversations span projects.
 
@@ -486,7 +486,7 @@ Net reduction: ~20 bash whitelist entries replaced by structured MCP tools.
 
 ## Success Criteria
 
-Source Sextant is successful when:
+Fledgling is successful when:
 
 - An agent can find "all Python function definitions containing 'parse'" without
   a single bash command

--- a/init-fledgling.sql
+++ b/init-fledgling.sql
@@ -1,18 +1,18 @@
--- Source Sextant: Init Script
+-- Fledgling: Init Script
 --
--- Entry point for: duckdb -init init-source-sextant.sql
+-- Entry point for: duckdb -init init-fledgling.sql
 --
 -- Loads extensions, configures sandbox, loads macros and tool
 -- publications, then starts the MCP server on stdio transport.
 --
 -- Usage:
---   duckdb -init /path/to/source-sextant/init-source-sextant.sql
+--   duckdb -init /path/to/fledgling/init-fledgling.sql
 --
--- The MCP client must set cwd to the source-sextant directory so
+-- The MCP client must set cwd to the fledgling directory so
 -- .read paths resolve correctly (they are relative to CWD, not to
 -- this init script). The target project root is passed separately
--- via the SEXTANT_PROJECT_ROOT environment variable, or by
--- pre-setting the sextant_root DuckDB variable.
+-- via the FLEDGLING_ROOT environment variable, or by
+-- pre-setting the session_root DuckDB variable.
 
 -- Suppress output during initialization
 .headers off
@@ -27,17 +27,17 @@ LOAD markdown;
 LOAD duck_tails;
 
 -- Capture project root before lockdown.
--- Priority: pre-set variable > SEXTANT_PROJECT_ROOT env var > CWD.
-SET VARIABLE sextant_root = COALESCE(
-    getvariable('sextant_root'),
-    NULLIF(getenv('SEXTANT_PROJECT_ROOT'), ''),
+-- Priority: pre-set variable > FLEDGLING_ROOT env var > CWD.
+SET VARIABLE session_root = COALESCE(
+    getvariable('session_root'),
+    NULLIF(getenv('FLEDGLING_ROOT'), ''),
     getenv('PWD')
 );
 
 -- Additional allowed directories (set before this point if needed).
--- Example: SET VARIABLE sextant_extra_dirs = ['/data/shared', '/opt/models'];
+-- Example: SET VARIABLE extra_dirs = ['/data/shared', '/opt/models'];
 
--- Path resolution macro (resolve relative paths against sextant_root)
+-- Path resolution macro (resolve relative paths against session_root)
 .read sql/sandbox.sql
 
 -- Load macro definitions
@@ -53,10 +53,10 @@ SET VARIABLE sextant_root = COALESCE(
 .read sql/tools/git.sql
 
 -- Lock down filesystem access (after all .read commands).
--- sextant_root is always allowed; extras are appended if set.
+-- session_root is always allowed; extras are appended if set.
 SET allowed_directories = list_concat(
-    [getvariable('sextant_root')],
-    COALESCE(getvariable('sextant_extra_dirs'), [])
+    [getvariable('session_root')],
+    COALESCE(getvariable('extra_dirs'), [])
 );
 SET enable_external_access = false;
 SET lock_configuration = true;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Source Sextant
+site_name: Fledgling
 site_description: MCP tools that help AI agents get their bearings in a codebase
 site_url: https://source-sextant.readthedocs.io
 repo_url: https://github.com/teaguesterling/source-sextant

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "source-sextant"
+name = "fledgling"
 version = "0.1.0"
 description = "MCP tools that help AI agents get their bearings in a codebase — unified SQL views over code, git, docs, and conversations, powered by DuckDB."
 readme = "README.md"

--- a/sql/code.sql
+++ b/sql/code.sql
@@ -1,4 +1,4 @@
--- Source Sextant: Code Intelligence Macros (sitting_duck)
+-- Fledgling: Code Intelligence Macros (sitting_duck)
 --
 -- Semantic code analysis powered by sitting_duck's AST parsing.
 -- Replaces grep-based code search with structure-aware queries.

--- a/sql/docs.sql
+++ b/sql/docs.sql
@@ -1,4 +1,4 @@
--- Source Sextant: Documentation Intelligence Macros (duckdb_markdown)
+-- Fledgling: Documentation Intelligence Macros (duckdb_markdown)
 --
 -- Structured access to markdown documentation. The documentation
 -- counterpart to sitting_duck's source code analysis.

--- a/sql/repo.sql
+++ b/sql/repo.sql
@@ -1,4 +1,4 @@
--- Source Sextant: Repository Intelligence Macros (duck_tails)
+-- Fledgling: Repository Intelligence Macros (duck_tails)
 --
 -- Structured access to git repository state. Replaces git CLI
 -- commands with composable, queryable results.

--- a/sql/sandbox.sql
+++ b/sql/sandbox.sql
@@ -1,16 +1,16 @@
--- Source Sextant: Path Resolution & Sandbox Setup
+-- Fledgling: Path Resolution & Sandbox Setup
 --
 -- Sets up the resolve() macro for converting relative paths to absolute.
 -- Used by all tool SQL templates to work with DuckDB's allowed_directories.
 --
--- REQUIRES: sextant_root variable must be set before loading this file.
+-- REQUIRES: session_root variable must be set before loading this file.
 --
 -- From CLI (init script):
---   SET VARIABLE sextant_root = getenv('PWD');
+--   SET VARIABLE session_root = getenv('PWD');
 --   .read sql/sandbox.sql
 --
 -- From Python (tests):
---   con.execute("SET VARIABLE sextant_root = '/path/to/project'")
+--   con.execute("SET VARIABLE session_root = '/path/to/project'")
 --   load_sql(con, "sandbox.sql")
 --
 -- Filesystem lockdown (allowed_directories, enable_external_access)
@@ -26,5 +26,5 @@
 CREATE OR REPLACE MACRO resolve(p) AS
     CASE WHEN p IS NULL THEN NULL
          WHEN p[1] = '/' THEN p
-         ELSE getvariable('sextant_root') || '/' || p
+         ELSE getvariable('session_root') || '/' || p
     END;

--- a/sql/source.sql
+++ b/sql/source.sql
@@ -1,4 +1,4 @@
--- Source Sextant: Source Retrieval Macros (read_lines)
+-- Fledgling: Source Retrieval Macros (read_lines)
 --
 -- Thin wrappers around read_lines that provide convenient interfaces
 -- for the common file-reading patterns agents use most.

--- a/sql/tools/code.sql
+++ b/sql/tools/code.sql
@@ -1,4 +1,4 @@
--- Source Sextant: Code Intelligence Tool Publications
+-- Fledgling: Code Intelligence Tool Publications
 --
 -- Publishes 4 MCP tools for AST-based code analysis.
 -- Macros are defined in sql/code.sql; this file only creates MCP bindings.

--- a/sql/tools/docs.sql
+++ b/sql/tools/docs.sql
@@ -1,4 +1,4 @@
--- Source Sextant: Documentation Tools
+-- Fledgling: Documentation Tools
 --
 -- MCP tool publications for structured markdown access.
 -- Wraps macros from sql/docs.sql.

--- a/sql/tools/git.sql
+++ b/sql/tools/git.sql
@@ -1,11 +1,11 @@
--- Source Sextant: Git Repository Tool Publications
+-- Fledgling: Git Repository Tool Publications
 --
 -- MCP tool publications for git repository state.
 -- Wraps macros from sql/repo.sql.
 --
--- Embeds sextant_root at publish time (getvariable is not available
+-- Embeds session_root at publish time (getvariable is not available
 -- in MCP tool execution context). Must be loaded after sandbox.sql
--- and repo.sql, with sextant_root already set.
+-- and repo.sql, with session_root already set.
 
 SELECT mcp_publish_tool(
     'GitChanges',
@@ -13,7 +13,7 @@ SELECT mcp_publish_tool(
     'SELECT hash, author, date, split_part(message, chr(10), 1) AS message
      FROM recent_changes(
         COALESCE(TRY_CAST(NULLIF($count, ''null'') AS INT), 10),
-        COALESCE(resolve(NULLIF($path, ''null'')), ''' || getvariable('sextant_root') || ''')
+        COALESCE(resolve(NULLIF($path, ''null'')), ''' || getvariable('session_root') || ''')
     )',
     '{"count": {"type": "string", "description": "Number of commits to return (default 10)"}, "path": {"type": "string", "description": "Repository path (default: project root)"}}',
     '[]',
@@ -23,7 +23,7 @@ SELECT mcp_publish_tool(
 SELECT mcp_publish_tool(
     'GitBranches',
     'List all branches with current branch marked.',
-    'SELECT * FROM branch_list(''' || getvariable('sextant_root') || ''')',
+    'SELECT * FROM branch_list(''' || getvariable('session_root') || ''')',
     '{}',
     '[]',
     'markdown'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
-"""Shared fixtures for source_sextant macro tests.
+"""Shared fixtures for fledgling macro tests.
 
-All tests use the source_sextant repo itself as test data (dog-fooding).
+All tests use the fledgling repo itself as test data (dog-fooding).
 """
 
 import json
@@ -102,7 +102,7 @@ def mcp_server():
     and resolve() for path sandboxing.
 
     Does NOT enable filesystem lockdown (enable_external_access = false)
-    because TestReadAsTable creates tmp_path files outside sextant_root.
+    because TestReadAsTable creates tmp_path files outside the project root.
     Lockdown is tested separately and enforced in the init script.
     """
     con = duckdb.connect(":memory:")
@@ -112,7 +112,7 @@ def mcp_server():
     con.execute("LOAD markdown")
     con.execute("LOAD duck_tails")
     # Sandbox: set root and load resolve() macro
-    con.execute(f"SET VARIABLE sextant_root = '{PROJECT_ROOT}'")
+    con.execute(f"SET VARIABLE session_root = '{PROJECT_ROOT}'")
     load_sql(con, "sandbox.sql")
     # Macros
     load_sql(con, "source.sql")

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -41,7 +41,7 @@ class TestDocOutline:
         ).fetchall()
         ids = [r[0] for r in rows]
         assert "architecture" in ids
-        assert "what-is-source-sextant" in ids
+        assert "what-is-fledgling" in ids
 
     def test_multiple_files_via_glob(self, docs_macros):
         pattern = PROJECT_ROOT + "/docs/vision/*.md"

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -127,7 +127,7 @@ class TestFileAtVersion:
             "SELECT content FROM file_at_version('docs/vision/PRODUCT_SPEC.md', 'HEAD', ?)",
             [REPO_PATH],
         ).fetchall()
-        assert "Source Sextant" in rows[0][0]
+        assert "Fledgling" in rows[0][0]
 
     def test_file_columns(self, repo_macros):
         desc = repo_macros.execute(

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -31,7 +31,7 @@ class TestReadSource:
         rows = source_macros.execute(
             "SELECT content FROM read_source(?, '1')", [SPEC_PATH]
         ).fetchall()
-        assert "Source Sextant" in rows[0][0]
+        assert "Fledgling" in rows[0][0]
 
     def test_context_lines(self, source_macros):
         rows = source_macros.execute(


### PR DESCRIPTION
## Summary

- Renames all internal references across 29 files (146 insertions, 146 deletions — pure rename, no logic changes)
- Variable mapping: `sextant_root` → `session_root`, `sextant_extra_dirs` → `extra_dirs`, `SEXTANT_PROJECT_ROOT` → `FLEDGLING_ROOT`, `source_sextant` → `fledgling` (MCP key), `Source Sextant` → `Fledgling` (branding)
- Renames `init-source-sextant.sql` → `init-fledgling.sql`
- GitHub and ReadTheDocs URLs left as-is pending repo/hosting rename

## Test plan

- [x] Full test suite: 120 passed, 17 skipped, 13 failed (all pre-existing P2-001 file tool failures)
- [x] `git-HEAD` test (`test_content_matches_current`) passes post-commit
- [x] Grep verification: only GitHub/ReadTheDocs URLs and one historical note still reference "sextant"

🤖 Generated with [Claude Code](https://claude.com/claude-code)