### PR TITLE
P3-004: Publish GitTags MCP tool

### DIFF
--- a/sql/tools/git.sql
+++ b/sql/tools/git.sql
@@ -43,6 +43,15 @@ SELECT mcp_publish_tool(
 );
 
 SELECT mcp_publish_tool(
+    'GitTags',
+    'List all tags with metadata. Shows tag name, commit hash, tagger, date, and whether annotated.',
+    'SELECT * FROM tag_list(''' || getvariable('session_root') || ''')',
+    '{}',
+    '[]',
+    'markdown'
+);
+
+SELECT mcp_publish_tool(
     'GitDiffFile',
     'Line-level unified diff for a specific file between two git revisions. Shows additions, removals, and context lines.',
     'SELECT * FROM file_diff(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,7 @@ def all_macros(con):
     return con
 
 
-# The 16 V1 custom tools that should be published in all profiles
+# The 17 V1 custom tools that should be published in all profiles
 V1_TOOLS = [
     "ListFiles",
     "ReadLines",
@@ -132,6 +132,7 @@ V1_TOOLS = [
     "MDSection",
     "GitChanges",
     "GitBranches",
+    "GitTags",
     "Help",
     "ChatSessions",
     "ChatSearch",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -411,6 +411,13 @@ class TestGitBranches:
         assert md_row_count(text) > 0
 
 
+class TestGitTags:
+    def test_executes_without_error(self, mcp_server):
+        text = call_tool(mcp_server, "GitTags", {})
+        # Repo may or may not have tags; just verify the tool runs
+        assert text is not None
+
+
 class TestGitShow:
     def test_returns_file_at_head(self, mcp_server):
         text = call_tool(mcp_server, "GitShow", {


### PR DESCRIPTION
## Summary
- Publishes the existing `tag_list` macro as the `GitTags` MCP tool via `mcp_publish_tool()`
- Adds MCP integration test (`TestGitTags`) verifying the tool executes without error
- Updates `V1_TOOLS` list in conftest.py (16 → 17) to keep profile tests passing

## Test plan
- [x] `TestGitTags` passes (tool executes, returns result)
- [x] Full test suite passes (205+ tests, 0 failures)
- [x] Profile tests pass with updated tool count

🤖 Generated with [Claude Code](https://claude.com/claude-code)