### PR TITLE
P2-008: MVP validation and MCP integration

### DIFF
--- a/.lq/commands.toml
+++ b/.lq/commands.toml
@@ -21,3 +21,9 @@ cmd = "pytest --collect-only -q"
 description = "List all tests without running them. Useful for discovery."
 timeout = 30
 format = "pytest_text"
+
+[commands.fledgling-tool]
+tpl = "python scripts/call_tool.py {tool}"
+description = "Call a Fledgling MCP tool. Use extra=[...] for tool arguments as key=value pairs."
+timeout = 30
+format = "generic"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,10 @@
 {
   "mcpServers": {
+    "fledgling": {
+      "command": "sh",
+      "args": ["-c", "exec duckdb -init init-fledgling.sql"],
+      "cwd": "."
+    },
     "blq_mcp": {
       "command": "blq",
       "args": [

--- a/config/claude-code.example.json
+++ b/config/claude-code.example.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "fledgling": {
-      "command": "duckdb",
-      "args": ["-init", "init-fledgling.sql"],
+      "command": "sh",
+      "args": ["-c", "exec duckdb -init init-fledgling.sql"],
       "cwd": "/absolute/path/to/fledgling",
       "env": {
         "FLEDGLING_ROOT": "/path/to/your/project"

--- a/docs/tasks/P2-009-mcp-path-resolution.md
+++ b/docs/tasks/P2-009-mcp-path-resolution.md
@@ -1,0 +1,159 @@
+# P2-009: MCP Path Resolution and Server Launch Cleanup
+
+**Status:** Not started
+**Priority:** P2 (required before production release)
+**Depends on:** P2-008 (MVP validation)
+
+## Problem
+
+Two related issues make the current MCP integration fragile and hard to maintain:
+
+### 1. `getvariable()` is unavailable in MCP tool execution context
+
+`duckdb_mcp` executes tool SQL templates in a context where `getvariable()` returns
+NULL. This means the `resolve()` macro — which depends on
+`getvariable('session_root')` — cannot work in tool templates. Every tool that
+accepts a file path must instead inline a `CASE WHEN $p[1] = '/' THEN $p ELSE
+'<embedded_root>/' || $p END` expression at publish time.
+
+This is currently duplicated across 9 tool templates in 3 files (`files.sql`,
+`code.sql`, `docs.sql`). Adding or modifying a tool requires remembering this
+pattern, and getting the quoting right inside `mcp_publish_tool()` string
+literals is error-prone.
+
+### 2. `PWD` not set when Claude Code spawns MCP servers
+
+Claude Code spawns `duckdb` via `child_process` without a shell, so the `PWD`
+environment variable is not set. The init script's fallback chain
+(`getvariable('session_root')` > `FLEDGLING_ROOT` > `PWD`) fails silently,
+leaving `session_root` as NULL.
+
+Current workaround: `.mcp.json` uses `sh -c "exec duckdb -init ..."` to get a
+shell that sets `PWD`. This works but adds an unnecessary process layer and
+looks wrong to anyone reading the config.
+
+## Current Workarounds
+
+- **Inline path resolution** in every tool template via embedded `session_root`
+  at publish time (verbose, 9 duplicated expressions)
+- **`sh -c` wrapper** in `.mcp.json` to ensure `PWD` is set (fragile, non-obvious)
+- **`CURRENT_TIMESTAMP::TIMESTAMP` cast** in conversation tools to work around
+  `TIMESTAMPTZ - INTERVAL` not being supported in MCP context
+
+## Options to Evaluate
+
+### Option A: Upstream fix — `getvariable()` in MCP context
+
+File an issue against `duckdb_mcp` requesting that `getvariable()` work inside
+tool SQL templates. This would let `resolve()` work natively and eliminate all
+inline path resolution.
+
+**Pros:** Cleanest fix, zero code on our side, benefits all duckdb_mcp users.
+**Cons:** Depends on upstream timeline. May have security implications they need
+to consider (tool templates accessing arbitrary variables).
+
+### Option B: Publish-time `_resolve()` helper
+
+Create a SQL scalar macro at init time that hardcodes `session_root`:
+
+```sql
+-- Generated at init time, after session_root is set
+CREATE OR REPLACE MACRO _resolve(p) AS
+    CASE WHEN p IS NULL THEN NULL
+         WHEN p[1] = '/' THEN p
+         ELSE '/actual/session/root/' || p
+    END;
+```
+
+This wouldn't work if DuckDB evaluates macros lazily (referencing the variable
+at call time, not definition time). Needs testing to confirm whether scalar
+macro bodies are captured or deferred.
+
+**Pros:** Single definition, all tool templates just call `_resolve($param)`.
+**Cons:** May not work due to macro evaluation semantics. Adds a second
+`resolve` variant that could confuse contributors.
+
+### Option C: Wrapper shell script
+
+Replace `sh -c "exec duckdb -init ..."` with a proper `scripts/serve.sh`:
+
+```sh
+#!/bin/sh
+# Fledgling MCP server launcher
+# Sets PWD and session_root reliably before starting DuckDB
+cd "${FLEDGLING_ROOT:-.}" || exit 1
+exec duckdb -init init-fledgling.sql
+```
+
+`.mcp.json` becomes:
+
+```json
+{
+  "command": "./scripts/serve.sh",
+  "cwd": "."
+}
+```
+
+**Pros:** Clean `.mcp.json`, single place for launch logic, can add logging or
+error handling. Portable across shells.
+**Cons:** Doesn't fix the `getvariable()` issue (still need inline resolution
+in tool templates). Adds a file to maintain.
+
+### Option D: DuckDB extension for path resolution
+
+Write a small DuckDB extension that provides `resolve_path(root, path)` as a
+native function. Unlike macros, extension functions are always available in any
+execution context including MCP tools.
+
+**Pros:** Works everywhere, proper function semantics, could add features like
+path normalization or symlink resolution.
+**Cons:** New build dependency, extension maintenance burden, increases
+packaging complexity (P3-006).
+
+### Option E: Template generation
+
+Generate tool SQL files from templates at build/init time, substituting
+`session_root` into the SQL before loading. Could use `sed`, `envsubst`, or a
+small Python script.
+
+**Pros:** Clean tool templates (just use `$SESSION_ROOT/` prefix), no runtime
+workarounds.
+**Cons:** Adds a build step, complicates the init flow, generated files could
+get stale.
+
+## Recommended Approach
+
+Evaluate in this order:
+
+1. **Test Option B first** — if scalar macros capture values at definition time,
+   this is the lowest-effort fix. One macro definition replaces 9 inline
+   expressions.
+2. **Implement Option C regardless** — a wrapper script is better than `sh -c`
+   in `.mcp.json` even if other fixes land.
+3. **File Option A upstream** — even if we solve it locally, the upstream fix
+   benefits the ecosystem.
+4. **Option D as fallback** — only if macro capture doesn't work and we need a
+   clean long-term solution.
+5. **Option E as last resort** — template generation adds complexity that should
+   be avoided unless nothing else works.
+
+## Acceptance Criteria
+
+- [ ] Relative paths work in all tool templates without inline CASE expressions
+- [ ] `.mcp.json` does not require `sh -c` wrapper
+- [ ] `resolve()` or equivalent works in MCP tool execution context
+- [ ] All existing tests pass
+- [ ] CLAUDE.md updated to document the chosen approach
+- [ ] DuckDB quirk documented (or removed if upstream fixes land)
+
+## Files Affected
+
+- `sql/tools/files.sql` — 3 inline path resolutions
+- `sql/tools/code.sql` — 4 inline path resolutions
+- `sql/tools/docs.sql` — 2 inline path resolutions
+- `sql/tools/conversations.sql` — TIMESTAMPTZ cast workaround
+- `sql/sandbox.sql` — `resolve()` macro definition
+- `.mcp.json` — `sh -c` wrapper
+- `config/claude-code.example.json` — example config
+- `init-fledgling-base.sql` — session_root initialization
+- `CLAUDE.md` — quirk documentation

--- a/scripts/call_tool.py
+++ b/scripts/call_tool.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Call a Fledgling MCP tool from the command line.
+
+Usage:
+    python scripts/call_tool.py ToolName [key=value ...]
+
+Examples:
+    python scripts/call_tool.py Help
+    python scripts/call_tool.py ListFiles pattern='sql/tools/*.sql'
+    python scripts/call_tool.py ReadLines file_path=CLAUDE.md lines=1-10
+    python scripts/call_tool.py GitChanges count=5
+    python scripts/call_tool.py CodeStructure file_pattern='tests/conftest.py'
+"""
+
+import json
+import os
+import sys
+
+# Import shared test infrastructure
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tests"))
+from conftest import _create_mcp_server, mcp_request, call_tool  # noqa: E402
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__.strip(), file=sys.stderr)
+        sys.exit(1)
+
+    tool_name = sys.argv[1]
+
+    # Parse key=value arguments
+    args = {}
+    for arg in sys.argv[2:]:
+        if "=" not in arg:
+            print(f"Error: arguments must be key=value, got: {arg}",
+                  file=sys.stderr)
+            sys.exit(1)
+        key, value = arg.split("=", 1)
+        args[key] = value
+
+    # Create server with analyst profile, loading real conversation data
+    # if available. Falls back to empty conversations on parse errors
+    # (some JSONL files may be malformed).
+    conv_root = os.path.expanduser("~/.claude/projects")
+    conv_pattern = os.path.join(conv_root, "*/*.jsonl")
+    import glob as globmod
+    conv_path = conv_pattern if globmod.glob(conv_pattern) else None
+    try:
+        con = _create_mcp_server("profiles/analyst.sql",
+                                 conv_jsonl_path=conv_path)
+    except Exception:
+        con = _create_mcp_server("profiles/analyst.sql")
+
+    try:
+        result = call_tool(con, tool_name, args)
+        print(result)
+    except AssertionError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        con.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/tools/code.sql
+++ b/sql/tools/code.sql
@@ -3,14 +3,16 @@
 -- Publishes 4 MCP tools for AST-based code analysis.
 -- Macros are defined in sql/code.sql; this file only creates MCP bindings.
 --
--- mcp_publish_tool(name, description, sql_template, properties_json, required_json, format)
--- format = 'markdown' renders results as markdown tables.
+-- Embeds session_root at publish time (getvariable is not available
+-- in MCP tool execution context). Must be loaded after sandbox.sql
+-- and code.sql, with session_root already set.
 
 SELECT mcp_publish_tool(
     'FindDefinitions',
     'AST-based definition search — not grep. Finds functions, classes, and variable definitions. Use name_pattern with SQL LIKE wildcards (%) to filter by name.',
     'SELECT * FROM find_definitions(
-        resolve($file_pattern),
+        CASE WHEN $file_pattern[1] = ''/'' THEN $file_pattern
+             ELSE ''' || getvariable('session_root') || '/'' || $file_pattern END,
         COALESCE(NULLIF($name_pattern, ''null''), ''%'')
     )',
     '{"file_pattern": {"type": "string", "description": "Glob pattern for files to search (e.g. src/**/*.py)"}, "name_pattern": {"type": "string", "description": "SQL LIKE pattern to filter by name (e.g. parse%). Default: % (all)"}}',
@@ -22,7 +24,8 @@ SELECT mcp_publish_tool(
     'FindCalls',
     'Find where functions or methods are called. Uses AST parsing to identify call sites, not text matching. Use name_pattern with SQL LIKE wildcards (%) to filter.',
     'SELECT * FROM find_calls(
-        resolve($file_pattern),
+        CASE WHEN $file_pattern[1] = ''/'' THEN $file_pattern
+             ELSE ''' || getvariable('session_root') || '/'' || $file_pattern END,
         COALESCE(NULLIF($name_pattern, ''null''), ''%'')
     )',
     '{"file_pattern": {"type": "string", "description": "Glob pattern for files to search (e.g. src/**/*.py)"}, "name_pattern": {"type": "string", "description": "SQL LIKE pattern to filter by call name (e.g. connect%). Default: % (all)"}}',
@@ -34,7 +37,8 @@ SELECT mcp_publish_tool(
     'FindImports',
     'Find import/include/require statements in source files. Uses AST parsing to identify language-specific import constructs.',
     'SELECT * FROM find_imports(
-        resolve($file_pattern)
+        CASE WHEN $file_pattern[1] = ''/'' THEN $file_pattern
+             ELSE ''' || getvariable('session_root') || '/'' || $file_pattern END
     )',
     '{"file_pattern": {"type": "string", "description": "Glob pattern for files to search (e.g. src/**/*.py)"}}',
     '["file_pattern"]',
@@ -45,7 +49,8 @@ SELECT mcp_publish_tool(
     'CodeStructure',
     'Top-level structural overview of source files: definitions with line counts. Shows what is defined in each file without implementation details.',
     'SELECT * FROM code_structure(
-        resolve($file_pattern)
+        CASE WHEN $file_pattern[1] = ''/'' THEN $file_pattern
+             ELSE ''' || getvariable('session_root') || '/'' || $file_pattern END
     )',
     '{"file_pattern": {"type": "string", "description": "Glob pattern for files to analyze (e.g. src/**/*.py)"}}',
     '["file_pattern"]',

--- a/sql/tools/conversations.sql
+++ b/sql/tools/conversations.sql
@@ -14,7 +14,7 @@ SELECT mcp_publish_tool(
      WHERE (NULLIF($project, ''null'') IS NULL
             OR project_dir ILIKE ''%'' || NULLIF($project, ''null'') || ''%'')
        AND (NULLIF($days, ''null'') IS NULL
-            OR started_at >= CURRENT_TIMESTAMP - (NULLIF($days, ''null'') || '' days'')::INTERVAL)
+            OR started_at >= CURRENT_TIMESTAMP::TIMESTAMP - (NULLIF($days, ''null'') || '' days'')::INTERVAL)
      ORDER BY started_at DESC
      LIMIT COALESCE(TRY_CAST(NULLIF($limit, ''null'') AS INT), 20)',
     '{"project": {"type": "string", "description": "Substring match on project directory name (case-insensitive)"}, "days": {"type": "string", "description": "Only sessions from last N days"}, "limit": {"type": "string", "description": "Max rows returned (default 20)"}}',
@@ -34,7 +34,7 @@ SELECT mcp_publish_tool(
        AND (NULLIF($project, ''null'') IS NULL
             OR s.project_dir ILIKE ''%'' || NULLIF($project, ''null'') || ''%'')
        AND (NULLIF($days, ''null'') IS NULL
-            OR sm.created_at >= CURRENT_TIMESTAMP - (NULLIF($days, ''null'') || '' days'')::INTERVAL)
+            OR sm.created_at >= CURRENT_TIMESTAMP::TIMESTAMP - (NULLIF($days, ''null'') || '' days'')::INTERVAL)
      ORDER BY sm.created_at DESC
      LIMIT COALESCE(TRY_CAST(NULLIF($limit, ''null'') AS INT), 20)',
     '{"query": {"type": "string", "description": "Search term (case-insensitive substring match)"}, "role": {"type": "string", "description": "Filter to user or assistant messages"}, "project": {"type": "string", "description": "Substring match on project directory name"}, "days": {"type": "string", "description": "Only messages from last N days"}, "limit": {"type": "string", "description": "Max rows returned (default 20)"}}',
@@ -57,7 +57,7 @@ SELECT mcp_publish_tool(
        AND (NULLIF($session_id, ''null'') IS NULL
             OR tf.session_id = NULLIF($session_id, ''null''))
        AND (NULLIF($days, ''null'') IS NULL
-            OR tf.first_used >= CURRENT_TIMESTAMP - (NULLIF($days, ''null'') || '' days'')::INTERVAL)
+            OR tf.first_used >= CURRENT_TIMESTAMP::TIMESTAMP - (NULLIF($days, ''null'') || '' days'')::INTERVAL)
      GROUP BY tf.tool_name
      ORDER BY total_calls DESC
      LIMIT COALESCE(TRY_CAST(NULLIF($limit, ''null'') AS INT), 50)',

--- a/sql/tools/docs.sql
+++ b/sql/tools/docs.sql
@@ -2,12 +2,17 @@
 --
 -- MCP tool publications for structured markdown access.
 -- Wraps macros from sql/docs.sql.
+--
+-- Embeds session_root at publish time (getvariable is not available
+-- in MCP tool execution context). Must be loaded after sandbox.sql
+-- and docs.sql, with session_root already set.
 
 SELECT mcp_publish_tool(
     'MDOutline',
     'Table of contents for markdown files. Use before reading sections to decide what''s relevant. Returns headings with section IDs, levels, and line ranges.',
     'SELECT * FROM doc_outline(
-        resolve($file_pattern),
+        CASE WHEN $file_pattern[1] = ''/'' THEN $file_pattern
+             ELSE ''' || getvariable('session_root') || '/'' || $file_pattern END,
         COALESCE(TRY_CAST(NULLIF($max_level, ''null'') AS INT), 3)
     )',
     '{"file_pattern": {"type": "string", "description": "Glob pattern for markdown files (e.g. docs/**/*.md or README.md)"}, "max_level": {"type": "string", "description": "Maximum heading level to include (1-6, default 3)"}}',
@@ -19,7 +24,8 @@ SELECT mcp_publish_tool(
     'MDSection',
     'Read a specific section from a markdown file by ID. Use MDOutline first to discover section IDs.',
     'SELECT * FROM read_doc_section(
-        resolve($file_path),
+        CASE WHEN $file_path[1] = ''/'' THEN $file_path
+             ELSE ''' || getvariable('session_root') || '/'' || $file_path END,
         $section_id
     )',
     '{"file_path": {"type": "string", "description": "Path to the markdown file"}, "section_id": {"type": "string", "description": "Section ID from MDOutline (e.g. installation, getting-started)"}}',

--- a/tests/data/validation-prompts/01-files.md
+++ b/tests/data/validation-prompts/01-files.md
@@ -1,0 +1,119 @@
+# Files Tier Validation
+
+## ListFiles
+
+### 1.1 Filesystem mode — relative glob
+
+```
+Use the Fledgling ListFiles tool to find all SQL files in the sql/ directory
+(not subdirectories). Use a relative path.
+
+Expected: Returns 7 files (code.sql, conversations.sql, docs.sql, help.sql,
+repo.sql, sandbox.sql, source.sql). Paths should be absolute.
+```
+
+### 1.2 Filesystem mode — recursive glob
+
+```
+Use Fledgling ListFiles to find all Python files in the tests/ directory
+recursively. Use the pattern tests/**/*.py.
+
+Expected: Returns test files including conftest.py, test_source.py,
+test_code.py, etc. At least 10 files.
+```
+
+### 1.3 Filesystem mode — no matches
+
+```
+Use Fledgling ListFiles with the pattern nonexistent_xyz_/*.foo
+
+Expected: Returns an empty table (headers only, no data rows).
+```
+
+### 1.4 Git mode — HEAD
+
+```
+Use Fledgling ListFiles in git mode to list files matching sql/tools/%.sql
+at commit HEAD.
+
+Expected: Returns 6 tool files (code.sql, conversations.sql, docs.sql,
+files.sql, git.sql, help.sql). Paths should be repo-relative (not absolute).
+```
+
+### 1.5 Git mode — specific commit
+
+```
+Use Fledgling ListFiles in git mode to list all files matching %.md at
+commit main.
+
+Expected: Returns markdown files as they exist on main branch. Should include
+CLAUDE.md, SKILL.md, README.md.
+```
+
+## ReadLines
+
+### 1.6 Whole file — relative path
+
+```
+Use Fledgling ReadLines to read sql/sandbox.sql (relative path, no line range).
+
+Expected: Returns all 30-31 lines of the file with line numbers. Content
+should include the resolve() macro definition.
+```
+
+### 1.7 Line range
+
+```
+Use Fledgling ReadLines to read lines 26-30 of sql/sandbox.sql.
+
+Expected: Returns exactly 5 lines showing the CREATE OR REPLACE MACRO
+resolve(p) definition.
+```
+
+### 1.8 Match filter
+
+```
+Use Fledgling ReadLines to read tests/conftest.py with match filter "def "
+(note the trailing space) to find all function definitions.
+
+Expected: Returns only lines containing "def " with their line numbers.
+Should include load_sql, call_tool, mcp_request, list_tools, etc.
+```
+
+### 1.9 Match with context
+
+```
+Use Fledgling ReadLines to read tests/conftest.py with match "call_tool"
+and ctx=2.
+
+Expected: Returns lines matching "call_tool" plus 2 lines of context above
+and below each match.
+```
+
+### 1.10 Git mode
+
+```
+Use Fledgling ReadLines to read sql/sandbox.sql at commit HEAD, lines 1-5.
+
+Expected: Returns the first 5 lines of the file as it exists in the HEAD
+commit. Should show the file header comment.
+```
+
+## ReadAsTable
+
+### 1.11 TOML file
+
+```
+Use Fledgling ReadAsTable to preview .lq/commands.toml.
+
+Expected: Returns structured data from the TOML file showing blq command
+configurations.
+```
+
+### 1.12 JSON file
+
+```
+Use Fledgling ReadAsTable to preview .mcp.json with a limit of 5 rows.
+
+Expected: Returns the MCP server configuration as structured table data.
+```

--- a/tests/data/validation-prompts/02-code.md
+++ b/tests/data/validation-prompts/02-code.md
@@ -1,0 +1,101 @@
+# Code Tier Validation
+
+## FindDefinitions
+
+### 2.1 All definitions in a file
+
+```
+Use Fledgling FindDefinitions to find all definitions in tests/conftest.py.
+
+Expected: Returns function definitions including load_sql, call_tool,
+mcp_request, list_tools, md_row_count, and fixture functions. Each row
+should have file_path, name, kind, start_line, end_line, and signature.
+```
+
+### 2.2 Filtered by name pattern
+
+```
+Use Fledgling FindDefinitions on tests/conftest.py with name_pattern=test_%
+
+Expected: Returns only definitions whose names start with "test_". These
+should be test helper functions if any exist.
+```
+
+### 2.3 Glob pattern across files
+
+```
+Use Fledgling FindDefinitions on tests/test_*.py with name_pattern=%sandbox%
+
+Expected: Returns definitions with "sandbox" in the name from test files.
+```
+
+### 2.4 SQL file definitions
+
+```
+Use Fledgling FindDefinitions on sql/sandbox.sql.
+
+Expected: Returns the CREATE macro definition. Kind should be
+DEFINITION_CLASS or similar for SQL CREATE statements.
+```
+
+## FindCalls
+
+### 2.5 Find calls to a specific function
+
+```
+Use Fledgling FindCalls on tests/conftest.py with name_pattern=load_sql.
+
+Expected: Returns all call sites where load_sql() is invoked. Should show
+20+ calls with file_path, name, start_line, and call_expression columns.
+```
+
+### 2.6 Find calls across multiple files
+
+```
+Use Fledgling FindCalls on tests/test_*.py with name_pattern=call_tool.
+
+Expected: Returns all test files that call call_tool(), showing the
+file path, line number, and call expression for each invocation.
+```
+
+## FindImports
+
+### 2.7 Python imports
+
+```
+Use Fledgling FindImports on tests/conftest.py.
+
+Expected: Returns import statements including json, os, pytest, duckdb.
+Each row should have file_path, name, import_statement, and start_line.
+```
+
+### 2.8 Imports across multiple files
+
+```
+Use Fledgling FindImports on tests/test_*.py.
+
+Expected: Returns imports from all test files. Should include conftest
+imports (call_tool, list_tools, etc.) and standard library imports.
+```
+
+## CodeStructure
+
+### 2.9 Python file structure
+
+```
+Use Fledgling CodeStructure on tests/conftest.py.
+
+Expected: Returns top-level structural elements: the module, function
+definitions, and class definitions with start_line, end_line, and
+line_count. Should NOT include implementation details — just the
+structural overview.
+```
+
+### 2.10 Structure of multiple files
+
+```
+Use Fledgling CodeStructure on sql/*.sql.
+
+Expected: Returns structural overview of all SQL macro files. Should
+show CREATE statements as top-level definitions.
+```

--- a/tests/data/validation-prompts/03-docs.md
+++ b/tests/data/validation-prompts/03-docs.md
@@ -1,0 +1,69 @@
+# Docs Tier Validation
+
+## MDOutline
+
+### 3.1 Full outline
+
+```
+Use Fledgling MDOutline on CLAUDE.md with no max_level filter.
+
+Expected: Returns all headings from CLAUDE.md with section_id, level,
+title, start_line, and end_line. Should include level 1, 2, and 3
+headings. The top-level heading should be "Fledgling: Project Conventions".
+```
+
+### 3.2 Filtered by level
+
+```
+Use Fledgling MDOutline on CLAUDE.md with max_level=1.
+
+Expected: Returns only the level 1 heading ("Fledgling: Project Conventions").
+```
+
+### 3.3 Multiple files
+
+```
+Use Fledgling MDOutline on docs/tasks/*.md with max_level=1.
+
+Expected: Returns the top-level heading from each task document. Should
+include task titles like "Security Profiles", "Init Script", etc.
+```
+
+### 3.4 SKILL.md outline
+
+```
+Use Fledgling MDOutline on SKILL.md with max_level=2.
+
+Expected: Returns the skill guide structure with sections like
+"Quick Reference", "File Navigation", "Code Intelligence", etc.
+```
+
+## MDSection
+
+### 3.5 Read a section by ID
+
+```
+Use Fledgling MDSection to read the "architecture" section from CLAUDE.md.
+
+Expected: Returns the content of the Architecture section. Should mention
+"SQL macros first, MCP tools second" and mcp_publish_tool().
+```
+
+### 3.6 Read a deeper section
+
+```
+Use Fledgling MDSection to read the "duckdb-quirks" section from CLAUDE.md.
+
+Expected: Returns the DuckDB Quirks section content listing known issues
+and workarounds (sitting_duck, LATERAL UNNEST, etc.).
+```
+
+### 3.7 Nested section ID
+
+```
+First use Fledgling MDOutline on SKILL.md to find section IDs, then use
+MDSection to read the "glob-patterns" section.
+
+Expected: MDOutline returns section IDs. MDSection returns the glob
+patterns guide with examples of glob syntax.
+```

--- a/tests/data/validation-prompts/04-git.md
+++ b/tests/data/validation-prompts/04-git.md
@@ -1,0 +1,42 @@
+# Git Tier Validation
+
+## GitChanges
+
+### 4.1 Default commit history
+
+```
+Use Fledgling GitChanges with no arguments.
+
+Expected: Returns the 10 most recent commits with hash, author, date,
+and message columns. Most recent commit should be first.
+```
+
+### 4.2 Limited count
+
+```
+Use Fledgling GitChanges with count=3.
+
+Expected: Returns exactly 3 commits.
+```
+
+### 4.3 Path-scoped history
+
+```
+Use Fledgling GitChanges with path=sql/ and count=5.
+
+Expected: Returns up to 5 commits that touched files under sql/.
+These should only be commits that modified SQL files.
+```
+
+## GitBranches
+
+### 4.4 List all branches
+
+```
+Use Fledgling GitBranches.
+
+Expected: Returns all local and remote branches with branch_name, hash,
+is_current, and is_remote columns. The current branch
+(chore/P2-008-mvp-validation or equivalent) should have is_current=true.
+Exactly one branch should be marked current.
+```

--- a/tests/data/validation-prompts/05-conversations.md
+++ b/tests/data/validation-prompts/05-conversations.md
@@ -1,0 +1,88 @@
+# Conversations Tier Validation
+
+Requires Claude Code conversation data in ~/.claude/projects/. If no
+conversation data exists, these tools return empty results (not errors).
+
+## ChatSessions
+
+### 5.1 Recent sessions
+
+```
+Use Fledgling ChatSessions with limit=5.
+
+Expected: Returns up to 5 most recent sessions with session_id,
+project_dir, slug, git_branch, started_at, duration, user_messages,
+total_tool_calls, distinct_tools_used, top_tool, total_tokens, and
+avg_cache_hit_rate columns. Ordered by started_at descending.
+```
+
+### 5.2 Project filter
+
+```
+Use Fledgling ChatSessions with project=sextant and limit=5.
+
+Expected: Returns only sessions from projects with "sextant" in the
+project directory name. Should include sessions from this repository.
+```
+
+### 5.3 Date range filter
+
+```
+Use Fledgling ChatSessions with days=3 and limit=5.
+
+Expected: Returns only sessions from the last 3 days.
+```
+
+## ChatSearch
+
+### 5.4 Basic search
+
+```
+Use Fledgling ChatSearch with query=resolve and limit=5.
+
+Expected: Returns messages containing "resolve" with session_id, slug,
+role, content_preview (truncated to 500 chars), and created_at.
+```
+
+### 5.5 Role-filtered search
+
+```
+Use Fledgling ChatSearch with query=test and role=user and limit=5.
+
+Expected: Returns only user messages containing "test". No assistant
+messages should appear.
+```
+
+## ChatToolUsage
+
+### 5.6 Overall tool usage
+
+```
+Use Fledgling ChatToolUsage with limit=10.
+
+Expected: Returns the 10 most-used tools across all sessions with
+tool_name, total_calls, sessions, first_used, and last_used columns.
+Common tools like Bash, Read, Edit should appear near the top.
+```
+
+### 5.7 Project-scoped usage
+
+```
+Use Fledgling ChatToolUsage with project=sextant and limit=10.
+
+Expected: Returns tool usage patterns only from sextant-related sessions.
+```
+
+## ChatDetail
+
+### 5.8 Session detail
+
+```
+First use Fledgling ChatSessions with limit=1 to get a session_id,
+then use ChatDetail with that session_id.
+
+Expected: Returns one row per tool used in that session, with session
+metadata (slug, project_dir, git_branch, started_at, duration, message
+counts, token counts) repeated on each row. The tool_name and calls
+columns show per-tool breakdown.
+```

--- a/tests/data/validation-prompts/06-help.md
+++ b/tests/data/validation-prompts/06-help.md
@@ -1,0 +1,41 @@
+# Help Tier Validation
+
+## Help
+
+### 6.1 Table of contents
+
+```
+Use Fledgling Help with no arguments.
+
+Expected: Returns the skill guide table of contents with section_id,
+title, and level columns. Should include sections for each tool category
+(File Navigation, Code Intelligence, Documentation, Git) plus Workflows
+and Tips sections. Content column should be NULL (TOC mode).
+```
+
+### 6.2 Read a specific section
+
+```
+Use Fledgling Help with section=quick-reference.
+
+Expected: Returns the Quick Reference section content with a summary
+of all available tools and their key parameters.
+```
+
+### 6.3 Read a workflow section
+
+```
+Use Fledgling Help with section=explore-an-unfamiliar-codebase.
+
+Expected: Returns a workflow guide describing how to use multiple
+Fledgling tools together to explore an unfamiliar codebase. Should
+reference specific tool names and suggest an order of operations.
+```
+
+### 6.4 Invalid section ID
+
+```
+Use Fledgling Help with section=nonexistent-section-xyz.
+
+Expected: Returns an empty result (no rows), not an error.
+```

--- a/tests/data/validation-prompts/07-analyst.md
+++ b/tests/data/validation-prompts/07-analyst.md
@@ -1,0 +1,79 @@
+# Analyst Built-in Tools Validation
+
+These tools are only available in the analyst profile (not core).
+
+## query
+
+### 7.1 Simple query
+
+```
+Use Fledgling query to run: SELECT 1 + 1 AS result
+Use markdown format.
+
+Expected: Returns a markdown table with one row showing result=2.
+```
+
+### 7.2 Query against internal data
+
+```
+Use Fledgling query to run:
+SELECT count(*) AS session_count FROM sessions()
+Use markdown format.
+
+Expected: Returns the count of loaded conversation sessions. Should be
+a positive number if conversation data exists.
+```
+
+### 7.3 Query with macros
+
+```
+Use Fledgling query to run:
+SELECT file_path FROM list_files(resolve('sql/*.sql'), NULL) LIMIT 3
+Use markdown format.
+
+Expected: May fail with resolve() returning NULL in MCP context (known
+issue, see P2-009). If so, use an absolute path or the ListFiles tool
+instead. This test documents the limitation.
+```
+
+### 7.4 Read-only enforcement
+
+```
+Use Fledgling query to run: CREATE TABLE test_rw AS SELECT 1
+
+Expected: Should fail with a permission error. The query tool only
+allows read-only operations.
+```
+
+## describe
+
+### 7.5 Describe a table
+
+```
+Use Fledgling describe on table raw_conversations.
+
+Expected: Returns column definitions including uuid, sessionId, type,
+message (a complex STRUCT), timestamp (TIMESTAMP type), and _source_file.
+```
+
+### 7.6 Describe a query
+
+```
+Use Fledgling describe with query: SELECT * FROM sessions() LIMIT 0
+
+Expected: Returns the schema of the sessions() macro output including
+session_id, project_dir, slug, git_branch, started_at, ended_at,
+duration, and message count columns.
+```
+
+## list_tables
+
+### 7.7 List all tables
+
+```
+Use Fledgling list_tables.
+
+Expected: Returns 2 tables: raw_conversations and _help_sections. Each
+entry should include database, schema, name, type, row_count_estimate,
+and column_count.
+```

--- a/tests/data/validation-prompts/08-integration.md
+++ b/tests/data/validation-prompts/08-integration.md
@@ -1,0 +1,112 @@
+# Integration Validation
+
+Multi-tool workflows that combine tools across tiers. These test the
+kind of real-world usage patterns an agent would follow.
+
+## Explore-then-read workflow
+
+### 8.1 Navigate to a function definition
+
+```
+Use Fledgling tools to find where the `call_tool` function is defined
+and read its full implementation. Do this in multiple steps:
+
+1. Use FindDefinitions on tests/conftest.py with name_pattern=call_tool
+2. Use the start_line and end_line from the result to read the function
+   body with ReadLines
+
+Expected: Step 1 finds the definition at a specific line range. Step 2
+reads just those lines, showing the complete function implementation
+including the auto-fill logic for missing params and the mcp_request call.
+```
+
+### 8.2 Understand a section of documentation
+
+```
+Use Fledgling tools to understand the DuckDB Quirks section of CLAUDE.md:
+
+1. Use MDOutline on CLAUDE.md to find the section ID for DuckDB Quirks
+2. Use MDSection to read the content of that section
+
+Expected: Step 1 shows the section_id (should be "duckdb-quirks").
+Step 2 returns the full content with numbered quirks and workarounds.
+```
+
+## Cross-reference workflow
+
+### 8.3 Trace a function's usage
+
+```
+Use Fledgling tools to understand how resolve() is used:
+
+1. Use FindDefinitions on sql/sandbox.sql to find the resolve macro
+2. Use FindCalls on sql/tools/*.sql with name_pattern=resolve to see
+   where it's called (note: these may have been replaced with inline
+   expressions — if no results, that confirms the P2-009 workaround)
+3. Use ListFiles with pattern=sql/tools/*.sql to see all tool files
+
+Expected: Shows the definition of resolve(), its call sites (or lack
+thereof after P2-009 workarounds), and the full list of tool files.
+```
+
+### 8.4 Review recent changes with context
+
+```
+Use Fledgling tools to review the most recent commit:
+
+1. Use GitChanges with count=1 to get the latest commit hash
+2. Use ListFiles in git mode with that commit hash and pattern=%.sql
+   to see which SQL files existed at that point
+3. Use GitBranches to see the current branch context
+
+Expected: Shows the latest commit, the SQL files in that commit, and
+the branch context. Demonstrates combining git tools for code review.
+```
+
+## Conversation analysis workflow
+
+### 8.5 Analyze your own tool usage
+
+```
+Use Fledgling tools to analyze how you use tools:
+
+1. Use ChatToolUsage with limit=10 to see most-used tools overall
+2. Use ChatSessions with project=sextant and limit=3 to find recent
+   sessions on this project
+3. Pick one session_id from step 2 and use ChatDetail to see its
+   tool breakdown
+
+Expected: Shows aggregate tool usage patterns, recent project sessions,
+and per-session detail. Demonstrates the conversation intelligence tier.
+```
+
+## Edge case workflow
+
+### 8.6 Empty results handling
+
+```
+Test that tools handle empty results gracefully:
+
+1. Use ListFiles with pattern=nonexistent_xyz_/*.foo
+2. Use FindDefinitions on sql/sandbox.sql with name_pattern=nonexistent_%
+3. Use MDOutline on sql/sandbox.sql (not a markdown file)
+
+Expected: All three should return empty result tables (headers but no
+data rows), not errors. Tools should degrade gracefully when given
+valid but unmatched inputs.
+```
+
+### 8.7 Large result sets
+
+```
+Use Fledgling tools with broad patterns:
+
+1. Use ListFiles with pattern=**/*.py to find all Python files
+2. Use FindDefinitions on tests/**/*.py to find all definitions in
+   test files
+3. Use CodeStructure on tests/conftest.py to get the full structure
+
+Expected: All return results without timeouts or truncation errors.
+Result counts should be reasonable (dozens of files, hundreds of
+definitions).
+```

--- a/tests/data/validation-prompts/README.md
+++ b/tests/data/validation-prompts/README.md
@@ -1,0 +1,33 @@
+# Fledgling Validation Prompts
+
+Structured prompts for validating each Fledgling MCP tool. Each file covers
+one tier of tools with test cases that exercise core functionality, edge cases,
+and parameter combinations.
+
+## How to use
+
+1. Start a Claude Code session with Fledgling configured in `.mcp.json`
+2. Copy a prompt from any file below and paste it into the session
+3. Verify the output matches the expected behavior described in the prompt
+4. Each prompt is self-contained — run them in any order
+
+## Alternative: blq harness
+
+For non-interactive validation, use the `fledgling-tool` blq command:
+
+```sh
+blq run fledgling-tool --args tool=ListFiles --extra "pattern=sql/*.sql"
+```
+
+## Files
+
+| File | Tools covered |
+|---|---|
+| `01-files.md` | ListFiles, ReadLines, ReadAsTable |
+| `02-code.md` | FindDefinitions, FindCalls, FindImports, CodeStructure |
+| `03-docs.md` | MDOutline, MDSection |
+| `04-git.md` | GitChanges, GitBranches |
+| `05-conversations.md` | ChatSessions, ChatSearch, ChatToolUsage, ChatDetail |
+| `06-help.md` | Help |
+| `07-analyst.md` | query, describe, list_tables (built-in analyst tools) |
+| `08-integration.md` | Multi-tool workflows that combine tools across tiers |


### PR DESCRIPTION
## Summary

- Wire Fledgling into `.mcp.json` for live use in Claude Code sessions
- Fix three DuckDB/duckdb_mcp compatibility issues discovered during real-data validation:
  - Subqueries inside `query()` not supported in DuckDB 1.4.4 (extracted to variable)
  - `timestamp` column inferred as VARCHAR with `ignore_errors=true` (added boundary cast)
  - `getvariable()` unavailable in MCP tool execution context (embed `session_root` at publish time in all tool templates)
- Fix `CURRENT_TIMESTAMP` returning `TIMESTAMPTZ` in MCP context (cast to `TIMESTAMP` in conversation tool date filters)
- Add CLI test harness (`scripts/call_tool.py`) and blq `fledgling-tool` command for testing tools without restarting Claude Code
- Add 59 validation prompts across 8 files covering all 18 custom tools + 3 built-in analyst tools
- Add P2-009 task doc for cleaning up path resolution workarounds before production

## Test plan

- [x] All existing pytest tests pass
- [x] All 18 custom tools validated live via MCP integration (relative paths)
- [x] All 3 built-in analyst tools validated (query, describe, list_tables)
- [x] Git mode tools validated (ListFiles with commit, ReadLines with commit)
- [ ] Run validation prompts from `tests/data/validation-prompts/` in a fresh session

🤖 Generated with [Claude Code](https://claude.com/claude-code)