### PR TITLE
P2-008: MVP validation suite and bug fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,10 @@ Per-profile entry point (e.g. init-fledgling-analyst.sql):
 
 10. **duckdb_mcp global server options** — `mcp_server_start()` uses process-global options. The first call in a process sets built-in tool visibility for all subsequent calls, regardless of connection. Profile tests use subprocess isolation (`_list_tools_for_profile()`) to work around this. Not an issue in production (each `duckdb -init` runs in its own process).
 
+11. **duck_tails git:// URIs and allowed_directories** — `duck_tails` resolves `git://` URIs to repo-relative paths internally, so `allowed_directories` sees `git://path/to/file` not the full absolute URI. Only the bare `git://` prefix works as an allowed directory. This is safe given `enable_external_access = false` prevents network access.
+
+12. **duckdb_mcp query tool is not read-only** — The built-in query tool (duckdb_mcp#34) does not enforce read-only access. DDL/DML like `CREATE TABLE` succeeds. `access_mode = 'read_only'` cannot be set after database open. Fix must happen in duckdb_mcp's query tool handler.
+
 <!-- blq:agent-instructions -->
 ## blq - Build Log Query
 

--- a/init-fledgling-analyst.sql
+++ b/init-fledgling-analyst.sql
@@ -16,11 +16,13 @@
 -- session_root is always allowed; extras are appended if set.
 -- conversations_root is intentionally excluded: conversation data is
 -- materialized into raw_conversations at startup (a point-in-time snapshot).
+-- git:// prefix allows ReadLines git mode (duck_tails resolves to repo-relative
+-- paths, so only the bare scheme works as an allowed prefix).
 -- NOTE: This block is duplicated in each entry point because profile SQL
 -- must run before lock_configuration. Extract to sql/lockdown.sql if a
 -- third profile is added.
 SET allowed_directories = list_concat(
-    [getvariable('session_root')],
+    [getvariable('session_root'), 'git://'],
     COALESCE(getvariable('extra_dirs'), [])
 );
 SET enable_external_access = false;

--- a/init-fledgling-core.sql
+++ b/init-fledgling-core.sql
@@ -15,11 +15,13 @@
 -- session_root is always allowed; extras are appended if set.
 -- conversations_root is intentionally excluded: conversation data is
 -- materialized into raw_conversations at startup (a point-in-time snapshot).
+-- git:// prefix allows ReadLines git mode (duck_tails resolves to repo-relative
+-- paths, so only the bare scheme works as an allowed prefix).
 -- NOTE: This block is duplicated in each entry point because profile SQL
 -- must run before lock_configuration. Extract to sql/lockdown.sql if a
 -- third profile is added.
 SET allowed_directories = list_concat(
-    [getvariable('session_root')],
+    [getvariable('session_root'), 'git://'],
     COALESCE(getvariable('extra_dirs'), [])
 );
 SET enable_external_access = false;

--- a/tests/data/validation-prompts/08-integration.md
+++ b/tests/data/validation-prompts/08-integration.md
@@ -91,9 +91,10 @@ Test that tools handle empty results gracefully:
 2. Use FindDefinitions on sql/sandbox.sql with name_pattern=nonexistent_%
 3. Use MDOutline on sql/sandbox.sql (not a markdown file)
 
-Expected: All three should return empty result tables (headers but no
-data rows), not errors. Tools should degrade gracefully when given
-valid but unmatched inputs.
+Expected: Steps 1 and 2 return empty result tables (headers but no
+data rows), not errors. Step 3 returns an error ("File is not a markdown
+file") — this is correct behavior since a SQL file is an invalid input
+type for markdown parsing, not a valid-but-unmatched input.
 ```
 
 ### 8.7 Large result sets


### PR DESCRIPTION
## Summary

- Integrate Fledgling MCP server into `.mcp.json` for live use
- Add 59-test validation prompt suite across 8 categories (files, code, docs, git, conversations, help, analyst, integration)
- Fix bugs discovered during validation: `getvariable()` unavailable in MCP context, malformed JSONL handling, TIMESTAMPTZ arithmetic, PWD not set by Claude Code
- Fix match+ctx in `read_source` macro (window function preserves context around matches)
- Fix ReadLines git mode blocked by sandbox (`git://` added to `allowed_directories`)
- Document path resolution workarounds (P2-009 task) and new DuckDB/MCP quirks (#11, #12)
- Add `scripts/call_tool.py` CLI harness for testing tools without session restarts

## Upstream issues filed

- [sitting_duck#37](https://github.com/teaguesterling/sitting_duck/issues/37) — SQL macro names extracted as `CREATE`, duplicate unnamed entries
- [duckdb_mcp#34](https://github.com/teaguesterling/duckdb_mcp/issues/34) — query tool does not enforce read-only access

## Test plan

- [x] All existing pytest tests pass
- [x] 53/59 validation prompts pass (4 were bugs now fixed, 1 expected failure for P2-009, 1 large-result overflow)
- [x] match+ctx verified: context lines shown around matches
- [x] git mode verified: ReadLines with commit param works through sandbox
- [x] Backward compatibility: match-only, ctx-only, and no-match/ctx modes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)