### PR TITLE
feat: full-text search over markdown and code (fts tier)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -27,6 +27,10 @@ Fledgling gives you structured, token-efficient access to the codebase you're wo
 | **ChatSearch** | Search across conversation messages | `query`, `role` |
 | **ChatToolUsage** | Tool usage frequency | `project`, `days` |
 | **ChatDetail** | Deep view of a single session | `session_id` |
+| **SearchContent** | BM25 full-text search over docs + code (requires rebuild first) | `query`, `kind`, `extractor`, `limit` |
+| **SearchDocs** | BM25 search over markdown sections | `query`, `limit` |
+| **SearchCode** | BM25 search over code (definition/comment/string) | `query`, `kind`, `limit` |
+| **FtsStats** | Diagnostic: counts per extractor/kind in the FTS index | — |
 
 ### Query-Only Macros
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@
 | [**pluckit**](https://github.com/teaguesterling/pluckit) | Fluent Python API — CSS selectors, jQuery-style chaining, mutations | `pip install ast-pluckit` |
 | [**squackit**](https://github.com/teaguesterling/squackit) | MCP server with smart defaults, caching, workflows, prompts | `pip install squackit` (coming soon) |
 
-## MCP Tools (20)
+## MCP Tools (24)
 
 | Tool | Purpose |
 |------|---------|
@@ -45,6 +45,10 @@
 | [ChatSearch](macros/conversations.md) | Full-text search across conversations |
 | [ChatToolUsage](macros/conversations.md) | Tool usage frequency |
 | [ChatDetail](macros/conversations.md) | Deep view of a single session |
+| [SearchContent](macros/fts.md) | BM25 full-text search across docs + code (definitions, comments, strings) |
+| [SearchDocs](macros/fts.md) | BM25 search over markdown sections |
+| [SearchCode](macros/fts.md) | BM25 search over code (definitions/comments/strings) |
+| [FtsStats](macros/fts.md) | Diagnostic: counts per extractor/kind in the FTS index |
 
 ## SQL Macros by Tier
 
@@ -65,6 +69,9 @@
 
 ### [Conversations](macros/conversations.md)
 `sessions` `messages` `content_blocks` `tool_calls` `tool_results` `token_usage` `tool_frequency` `bash_commands` `session_summary` `model_usage` `search_messages` `search_tool_inputs`
+
+### [Full-Text Search](macros/fts.md)
+`search_content` `search_docs` `search_code` `fts_stats`  *(rebuild via `Connection.rebuild_fts()` or `sql/fts_rebuild.sql`)*
 
 ## Python API
 

--- a/docs/macros/fts.md
+++ b/docs/macros/fts.md
@@ -1,0 +1,183 @@
+# Full-Text Search
+
+**Extension**: [`fts`](https://duckdb.org/docs/current/core_extensions/full_text_search) (bundled)
+
+BM25-based lexical search across markdown documentation and code (definitions, comments, and string literals). Extracted chunks live in a single `fts.content` table and are scored via DuckDB's built-in inverted-index implementation.
+
+Complementary to existing grep-style and AST-structural macros — this is the "find things containing these words" axis, where `find_definitions` answers "find the `parse_config` function" and `search_code` answers "find any code mentioning authentication".
+
+## At a glance
+
+Timings from this repo (~70 files, 6,000 indexed chunks, DuckDB 1.5.1):
+
+| Operation | Time |
+|---|---|
+| `fledgling.connect()` (cold, loads all modules) | ~6.3 s |
+| `rebuild_fts()` (full corpus re-index) | ~2.7 s |
+| `search_content('lockdown')` | ~25 ms |
+| `search_code('function_callers', filter_kind := 'definition')` | ~23 ms |
+
+Rebuild is a **manual** operation. The FTS index doesn't track source changes — call `rebuild_fts()` after files change. This is a known DuckDB FTS limitation, not an oversight.
+
+## Data shape: `fts.content`
+
+One row per indexed chunk. Deliberately under-specified so new extractors can be added without schema churn.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `BIGINT` | Primary key, assigned at rebuild time |
+| `file_path` | `VARCHAR` | Absolute path to the source file |
+| `start_line` / `end_line` | `INTEGER` | Location within the source file |
+| `extractor` | `VARCHAR` | `'markdown'` or `'sitting_duck'` |
+| `kind` | `VARCHAR` | `'doc_section'`, `'definition'`, `'comment'`, `'string'` |
+| `name` | `VARCHAR` | Displayable identifier (symbol name or heading title; `NULL` for comments/strings) |
+| `ordinal` | `INTEGER` | Extractor-defined opaque int (heading level for markdown, AST `node_id` for sitting_duck) |
+| `attrs` | `JSON` | Per-extractor extras (`semantic_type`, `heading_path`, etc.) |
+| `text` | `VARCHAR` | The searchable content — BM25 index target |
+
+Storage location follows the current connection. An in-memory DuckDB gives an ephemeral index; a file-backed DuckDB persists it (though you still need to rebuild after source changes).
+
+## Rebuild
+
+### SQL script
+
+```sql
+-- Defaults: '**/*.md' and '**/*.py'
+.read sql/fts_rebuild.sql
+
+-- Or narrow the scope
+SET VARIABLE fts_code_glob = 'src/**/*.py';
+SET VARIABLE fts_docs_glob = 'docs/**/*.md';
+.read sql/fts_rebuild.sql
+```
+
+### Python API
+
+```python
+import fledgling
+con = fledgling.connect(root='.')
+con.rebuild_fts()                              # defaults
+con.rebuild_fts(code_glob='src/**/*.py')       # narrow code scope
+con.rebuild_fts(docs_glob='README.md')         # single doc file
+```
+
+The rebuild:
+1. `DELETE FROM fts.content`
+2. Inserts fresh rows from markdown sections (via `read_markdown_sections`), AST definitions / comments / strings (via `read_ast`)
+3. Dedupes tree-sitter's nested string nodes (outer vs. `string_content`) using `QUALIFY`
+4. Rebuilds the BM25 index with `PRAGMA create_fts_index(..., overwrite = 1)`
+
+## Search macros
+
+### `search_content`
+
+Unified BM25 search across all indexed content. Optional filters narrow by kind or extractor.
+
+```sql
+search_content(query, filter_kind := NULL, filter_extractor := NULL, limit_n := 20)
+```
+
+**Returns**: all columns from `fts.content`, plus `score` (BM25, higher = better match). Ordered by score descending.
+
+```sql
+-- Ranked hits across docs and code
+SELECT file_path, kind, name, score
+FROM search_content('session_root sandbox');
+
+-- Only docs
+SELECT * FROM search_content('authentication', filter_kind := 'doc_section');
+
+-- Only code, limit to 5
+SELECT * FROM search_content('retry', filter_extractor := 'sitting_duck', limit_n := 5);
+```
+
+### `search_docs`
+
+Thin wrapper that pins `filter_kind := 'doc_section'`. Example:
+
+```sql
+SELECT file_path, name AS heading, score
+FROM search_docs('session_root sandbox', 5);
+```
+
+Output on this repo:
+
+```
+file                              lines    score  text
+P2-005-init-and-config.md         40-71     3.56  sql/sandbox.sql … Optional: override
+P2-005-init-and-config.md         91-98     3.20  What's sandboxed … All `read_lines`…
+P2-005-init-and-config.md         14-22     2.94  Files … | File | Action | …
+```
+
+### `search_code`
+
+BM25 over code chunks. Filter by `kind` (`'definition'`, `'comment'`, `'string'`).
+
+```sql
+SELECT file_path, start_line, name, score
+FROM search_code('function_callers', filter_kind := 'definition');
+```
+
+Output:
+
+```
+file                              line  name                              score
+test_code.py                       317  test_caller_is_enclosing_function  5.18
+test_connection.py                 320  test_find_definitions_and_callers  3.20
+test_code.py                       300  test_finds_callers                 3.20
+test_e2e_integration.py            188  test_find_functions                2.34
+```
+
+Kind examples:
+
+```sql
+-- Only docstrings and string constants (includes Python triple-quoted strings)
+SELECT * FROM search_code('SELECT FROM read_ast', filter_kind := 'string');
+
+-- Only line comments
+SELECT * FROM search_code('workaround', filter_kind := 'comment');
+```
+
+### `fts_stats`
+
+Diagnostic macro — row and file counts per extractor/kind. No index required.
+
+```sql
+SELECT * FROM fts_stats();
+```
+
+```
+ extractor     | kind        | row_count | file_count
+---------------+-------------+-----------+-----------
+ markdown      | doc_section |       989 |         72
+ sitting_duck  | comment     |       589 |         56
+ sitting_duck  | definition  |      1408 |         60
+ sitting_duck  | string      |      3225 |         64
+```
+
+## MCP tools
+
+Four tools are published in all profiles:
+
+| Tool | Purpose |
+|---|---|
+| **SearchContent** | Unified BM25 search with kind/extractor filters |
+| **SearchDocs** | BM25 over markdown sections |
+| **SearchCode** | BM25 over code (definition/comment/string) |
+| **FtsStats** | Counts of what's currently indexed — check before searching |
+
+All four require a populated index. If agents call `SearchContent` before `rebuild_fts()` has run, they'll get a clear "function does not exist" error directing them to rebuild.
+
+## Caveats
+
+- **Manual rebuild.** The FTS index doesn't update when `fts.content` changes. Call `rebuild_fts()` after source file edits or re-run the SQL script. See [duckdb/duckdb#3543](https://github.com/duckdb/duckdb/issues/3543) for the upstream limitation.
+- **Tokenization.** BM25 uses the default FTS tokenizer (Porter stemmer, English stopwords, lowercase, strips accents). Queries like `'zzzzzzzz_xyzzy'` get split on non-alphanumerics. A literal multi-word phrase won't require all words unless you pass `conjunctive := 1` (DuckDB feature — not yet exposed in our macros; easy to add).
+- **Self-matching on dogfooded test data.** Test files that mention search terms as string literals will match themselves. Mostly harmless; use computed terms in assertions about "no matches".
+- **String dedup.** Tree-sitter reports nested string nodes (outer literal + `string_content`). The rebuild keeps only the longest per `(file, line span)`, which is the outer quoted form. You'll see `"template"` in results, not a separate `template` row.
+- **Extension stub index.** `sql/fts.sql` creates an empty index at load time so the search macros can reference `fts_fts_content.match_bm25` without errors. Running on a persistent DB with an already-populated index: the stub replaces the real index, so rebuild after reconnect. (If this becomes painful we can add a "skip if already built" Python guard.)
+
+## Design notes
+
+- **One table, many extractors.** Rather than a separate table per kind, one `fts.content` table with a discriminator (`extractor`, `kind`) and opaque extensibility (`name`, `ordinal`, `attrs`). Adding a new extractor (e.g. conversation messages, SQL macro definitions) is an INSERT path change, not a schema change.
+- **Storage is caller-controlled.** Fledgling doesn't pick `.fledgling/index.db` — whatever database you've opened or ATTACHed holds the index.
+- **Complement to AST and grep, not a replacement.** `find_definitions` answers "where is this symbol defined" (structural); `search_code` answers "what mentions these words" (lexical). Use both.

--- a/docs/macros/fts.md
+++ b/docs/macros/fts.md
@@ -138,6 +138,40 @@ SELECT * FROM search_code('SELECT FROM read_ast', filter_kind := 'string');
 SELECT * FROM search_code('workaround', filter_kind := 'comment');
 ```
 
+### `find_code_ranked`
+
+Composition of `ast_select` (structural) with FTS (lexical ranking). Pass a structural selector AND a BM25 query; results are all the nodes matching the selector that also appear in `fts.content`, ordered by relevance.
+
+```sql
+find_code_ranked(file_pattern, selector, fts_query, lang := NULL)
+```
+
+**Returns**: `file_path`, `start_line`, `end_line`, `name`, `kind`, `node_type`, `peek`, `score`
+
+This is the "fuzzy front door for structural navigation" — where `find_definitions` demands a name prefix and `search_code` has no structural constraint, `find_code_ranked` gives you "all functions, ranked by how well they match this concept":
+
+```sql
+-- Functions most relevant to 'function_callers'
+SELECT name, score
+FROM find_code_ranked('**/*.py', '.func', 'function_callers')
+LIMIT 5;
+```
+
+```
+file                       line  name                               score
+test_code.py                317  test_caller_is_enclosing_function   5.11
+test_code.py                300  test_finds_callers                  3.14
+test_connection.py          320  test_find_definitions_and_callers   3.14
+test_e2e_integration.py     188  test_find_functions                 2.32
+test_e2e_integration.py     211  test_view_functions                 2.32
+```
+
+**How it works**: `ast_select` returns rows with `node_id`. Each code row in `fts.content` has `ordinal = node_id`. A JOIN on `(file_path, ordinal = node_id)` bridges the two, then `match_bm25()` scores each match.
+
+**Coverage**: only rows that also exist in `fts.content` are returned. Selectors that match kinds we don't index (`.loop`, `.if`, `.call`) will yield zero rows regardless of the query.
+
+**Cost**: `ast_select` re-parses the matched files, so `find_code_ranked` is slower than `search_code` (~500ms vs. ~25ms on this repo). If you already know you want a lexical answer, prefer `search_code`. Use this when the structural constraint matters.
+
 ### `fts_stats`
 
 Diagnostic macro — row and file counts per extractor/kind. No index required.

--- a/fledgling/connection.py
+++ b/fledgling/connection.py
@@ -146,10 +146,10 @@ def _split_sql(sql: str) -> list[str]:
 _DEFAULT_MODULES = [
     "sandbox", "dr_fledgling",
     "source", "code", "docs", "repo", "structural", "workflows",
-    "conversations", "help",
+    "conversations", "help", "fts",
 ]
 
-_DEFAULT_EXTENSIONS = ["read_lines", "sitting_duck", "markdown", "duck_tails"]
+_DEFAULT_EXTENSIONS = ["read_lines", "sitting_duck", "markdown", "duck_tails", "fts"]
 
 
 # ── Compose helpers (Delta 4) ────────────────────────────────────────
@@ -488,6 +488,42 @@ class Connection:
         from fledgling.tools import Tools
         self._con = con
         self._tools = Tools(con)
+
+    def rebuild_fts(
+        self,
+        docs_glob: str = "**/*.md",
+        code_glob: str = "**/*.py",
+        sql_dir: Optional[Path] = None,
+    ) -> None:
+        """Rebuild the FTS index from scratch.
+
+        Wipes and re-populates ``fts.content`` from markdown files and AST
+        nodes matching ``docs_glob`` / ``code_glob``, then (re)creates the
+        BM25 inverted index via ``PRAGMA create_fts_index``.
+
+        The FTS index does not auto-update on INSERT/UPDATE/DELETE — call
+        this after source files change.
+
+        Args:
+            docs_glob: Glob for markdown files, relative to ``session_root``.
+                Default ``'**/*.md'``.
+            code_glob: Glob for code files. Default ``'**/*.py'``.
+            sql_dir: Directory containing ``fts_rebuild.sql``. Auto-discovered
+                if None (same logic as ``load_macros``).
+
+        Raises:
+            FileNotFoundError: if ``fts_rebuild.sql`` cannot be located.
+        """
+        if sql_dir is None:
+            sql_dir = _find_sql_dir()
+        if sql_dir is None or not (sql_dir / "fts_rebuild.sql").exists():
+            raise FileNotFoundError(
+                "fts_rebuild.sql not found; ensure fledgling SQL sources "
+                "are available (pip install fledgling-mcp or dev checkout)."
+            )
+        self._con.execute("SET VARIABLE fts_docs_glob = ?", [docs_glob])
+        self._con.execute("SET VARIABLE fts_code_glob = ?", [code_glob])
+        _load_sql_file(self._con, sql_dir / "fts_rebuild.sql")
 
     def __getattr__(self, name: str):
         # First check macros

--- a/init/init-fledgling-base.sql
+++ b/init/init-fledgling-base.sql
@@ -17,6 +17,7 @@ LOAD read_lines;
 LOAD sitting_duck;
 LOAD markdown;
 LOAD duck_tails;
+LOAD fts;
 
 -- Capture project root before lockdown.
 -- Priority: pre-set variable > FLEDGLING_ROOT env var > CWD.
@@ -36,7 +37,7 @@ SET VARIABLE conversations_root = COALESCE(
 
 -- Fledgling metadata (read by dr_fledgling)
 SET VARIABLE fledgling_version = '0.8.2';
-SET VARIABLE fledgling_modules = ['source', 'code', 'docs', 'repo', 'structural', 'workflows', 'conversations', 'help'];
+SET VARIABLE fledgling_modules = ['source', 'code', 'docs', 'repo', 'structural', 'workflows', 'conversations', 'help', 'fts'];
 
 -- Additional allowed directories (set before this point if needed).
 -- Example: SET VARIABLE extra_dirs = ['/data/shared', '/opt/models'];
@@ -59,6 +60,8 @@ SET VARIABLE fledgling_modules = ['source', 'code', 'docs', 'repo', 'structural'
 
 .read sql/help.sql
 
+.read sql/fts.sql
+
 -- Publish MCP tools (comment out a line to disable that category)
 .read sql/tools/files.sql
 .read sql/tools/code.sql
@@ -67,3 +70,4 @@ SET VARIABLE fledgling_modules = ['source', 'code', 'docs', 'repo', 'structural'
 .read sql/tools/workflows.sql
 .read sql/tools/conversations.sql
 .read sql/tools/help.sql
+.read sql/tools/fts.sql

--- a/sql/fts.sql
+++ b/sql/fts.sql
@@ -1,0 +1,148 @@
+-- Fledgling: Full-Text Search Macros (fts)
+--
+-- BM25-based search over markdown documents and code (definitions and
+-- comments). Materializes extracted content into the fts.content table
+-- and builds an inverted index via PRAGMA create_fts_index.
+--
+-- Tables live in the `fts` schema of the current database. Persistence
+-- is caller-controlled: an in-memory DB gives an ephemeral index,
+-- a persistent DB gives a persistent index.
+--
+-- Schema columns:
+--   id         BIGINT     — primary key (assigned at rebuild time)
+--   file_path  VARCHAR    — source file (from read_ast / read_markdown_sections)
+--   start_line INTEGER
+--   end_line   INTEGER
+--   extractor  VARCHAR    — 'markdown' | 'sitting_duck'
+--   kind       VARCHAR    — 'doc_section' | 'definition' | 'comment' | 'string'
+--   name       VARCHAR    — displayable identifier (symbol or heading title)
+--   ordinal    INTEGER    — extractor-defined opaque int (see conventions below)
+--   attrs      JSON       — extractor-defined extras
+--   text       VARCHAR    — FTS target column
+--
+-- Per-extractor conventions for opaque fields (not enforced):
+--   markdown/doc_section:
+--     name    = section title
+--     ordinal = heading level (1-6)
+--     attrs   = {section_id, section_path, level}
+--     text    = title || '\n' || content
+--   sitting_duck/definition:
+--     name    = symbol name
+--     ordinal = AST node_id (for back-reference via read_ast)
+--     attrs   = {semantic_type, depth, parent_id}
+--     text    = name || ' ' || peek  (symbol + one-line signature)
+--   sitting_duck/comment:
+--     name    = NULL (comments have no name)
+--     ordinal = AST node_id
+--     attrs   = {semantic_type, depth, parent_id}
+--     text    = comment text (peek)
+--   sitting_duck/string:
+--     name    = NULL (string literals have no name)
+--     ordinal = AST node_id
+--     attrs   = {semantic_type, depth, parent_id}
+--     text    = string literal (peek) — includes Python docstrings,
+--               URLs, SQL, error messages. Filtered to length >= 8.
+--
+-- Rebuild is triggered externally (via sql/fts_rebuild.sql). This file
+-- installs only the schema, table, and search-side macros. Macros are
+-- lazy, so defining them is safe even before the index exists — but
+-- calling search_* before rebuild will error because the FTS index
+-- schema (fts_fts_content) doesn't exist yet.
+
+CREATE SCHEMA IF NOT EXISTS fts;
+
+CREATE TABLE IF NOT EXISTS fts.content (
+    id         BIGINT PRIMARY KEY,
+    file_path  VARCHAR,
+    start_line INTEGER,
+    end_line   INTEGER,
+    extractor  VARCHAR,
+    kind       VARCHAR,
+    name       VARCHAR,
+    ordinal    INTEGER,
+    attrs      JSON,
+    text       VARCHAR
+);
+
+-- Create a stub BM25 index so fts_fts_content.match_bm25 exists when
+-- the search macros below are parsed. DuckDB validates function refs
+-- at macro-definition time, so the target has to exist already.
+-- overwrite = 1 makes this idempotent across reloads; the rebuild
+-- script replaces this with a real index over the populated table.
+PRAGMA create_fts_index('fts.content', 'id', 'text', overwrite = 1);
+
+-- search_content: BM25 search across all indexed content.
+-- Optional filters narrow by kind and/or extractor.
+--
+-- Examples:
+--   SELECT * FROM search_content('authentication');
+--   SELECT * FROM search_content('auth', filter_kind := 'doc_section');
+--   SELECT * FROM search_content('login', filter_extractor := 'sitting_duck');
+CREATE OR REPLACE MACRO search_content(
+    query,
+    filter_kind := NULL,
+    filter_extractor := NULL,
+    limit_n := 20
+) AS TABLE
+    SELECT *
+    FROM (
+        SELECT
+            c.id,
+            c.file_path,
+            c.start_line,
+            c.end_line,
+            c.extractor,
+            c.kind,
+            c.name,
+            c.ordinal,
+            c.attrs,
+            c.text,
+            fts_fts_content.match_bm25(c.id, query) AS score
+        FROM fts.content c
+    ) scored
+    WHERE scored.score IS NOT NULL
+      AND (filter_kind IS NULL OR scored.kind = filter_kind)
+      AND (filter_extractor IS NULL OR scored.extractor = filter_extractor)
+    ORDER BY scored.score DESC
+    LIMIT limit_n;
+
+-- search_docs: FTS over markdown sections.
+--
+-- Examples:
+--   SELECT * FROM search_docs('installation');
+CREATE OR REPLACE MACRO search_docs(query, limit_n := 20) AS TABLE
+    SELECT * FROM search_content(
+        query,
+        filter_kind := 'doc_section',
+        limit_n := limit_n
+    );
+
+-- search_code: FTS over code content (definitions, comments, strings).
+-- Optional filter_kind narrows to 'definition', 'comment', or 'string'.
+--
+-- Examples:
+--   SELECT * FROM search_code('auth');
+--   SELECT * FROM search_code('auth', filter_kind := 'comment');
+CREATE OR REPLACE MACRO search_code(query, filter_kind := NULL, limit_n := 20) AS TABLE
+    SELECT * FROM search_content(
+        query,
+        filter_kind := filter_kind,
+        filter_extractor := 'sitting_duck',
+        limit_n := limit_n
+    );
+
+-- fts_stats: Row counts per extractor/kind. Diagnostic view of what's
+-- currently in the index. Does NOT require the FTS index to exist —
+-- just reads the content table directly.
+--
+-- Examples:
+--   SELECT * FROM fts_stats();
+CREATE OR REPLACE MACRO fts_stats() AS TABLE
+    SELECT
+        extractor,
+        kind,
+        count(*) AS row_count,
+        count(DISTINCT file_path) AS file_count
+    FROM fts.content
+    GROUP BY extractor, kind
+    ORDER BY extractor, kind;

--- a/sql/fts.sql
+++ b/sql/fts.sql
@@ -131,6 +131,47 @@ CREATE OR REPLACE MACRO search_code(query, filter_kind := NULL, limit_n := 20) A
         limit_n := limit_n
     );
 
+-- find_code_ranked: Structural search (via ast_select) with BM25 relevance
+-- ranking layered on top. Pass a structural selector AND a BM25 query;
+-- results are joined against fts.content on (file_path, ordinal=node_id)
+-- and ordered by score. Bridges fledgling's lexical and structural axes.
+--
+-- Useful for "all functions, but only the ones relevant to this concept"
+-- — find_code alone returns everything unranked; search_code alone has
+-- no structural filter; this combination gives you both.
+--
+-- Only returns rows that appear in fts.content (definition, comment, or
+-- string). Selectors matching other kinds (.loop, .if, .call) will have
+-- no join partners and return nothing. Requires rebuild_fts() first.
+--
+-- Examples:
+--   -- Functions ranked by relevance to 'auth retry'
+--   SELECT * FROM find_code_ranked('src/**/*.py', '.func', 'auth retry');
+--
+--   -- Classes mentioning 'connection pool'
+--   SELECT * FROM find_code_ranked('**/*.py', '.class', 'connection pool');
+--
+--   -- With explicit language override
+--   SELECT * FROM find_code_ranked(
+--       'src/**/*.rs', '.func', 'validate', lang := 'rust');
+CREATE OR REPLACE MACRO find_code_ranked(
+    file_pattern, selector, fts_query, lang := NULL
+) AS TABLE
+    SELECT
+        a.file_path,
+        a.start_line,
+        a.end_line,
+        a.name,
+        semantic_type_to_string(a.semantic_type) AS kind,
+        a.type AS node_type,
+        a.peek,
+        fts_fts_content.match_bm25(c.id, fts_query) AS score
+    FROM ast_select(file_pattern, selector, language := lang) a
+    JOIN fts.content c
+        ON c.file_path = a.file_path AND c.ordinal = a.node_id
+    WHERE fts_fts_content.match_bm25(c.id, fts_query) IS NOT NULL
+    ORDER BY score DESC, a.file_path, a.start_line;
+
 -- fts_stats: Row counts per extractor/kind. Diagnostic view of what's
 -- currently in the index. Does NOT require the FTS index to exist —
 -- just reads the content table directly.

--- a/sql/fts_rebuild.sql
+++ b/sql/fts_rebuild.sql
@@ -1,0 +1,149 @@
+-- Fledgling: FTS Rebuild Script
+--
+-- Fully rebuilds fts.content from markdown files and AST nodes, then
+-- (re)creates the BM25 inverted index.
+--
+-- Assumes sql/fts.sql has been loaded (schema + table + search macros
+-- exist) and that resolve() + session_root are set (init-fledgling-base
+-- does both).
+--
+-- Parameters (optional; set via SET VARIABLE before .read):
+--   fts_docs_glob — markdown file glob (default '**/*.md')
+--   fts_code_glob — code file glob    (default '**/*.py')
+--
+-- Usage:
+--   SET VARIABLE fts_code_glob = 'src/**/*.py';
+--   .read sql/fts_rebuild.sql
+
+-- Defaults (preserve caller-set values).
+SET VARIABLE fts_docs_glob = COALESCE(getvariable('fts_docs_glob'), '**/*.md');
+SET VARIABLE fts_code_glob = COALESCE(getvariable('fts_code_glob'), '**/*.py');
+
+-- Wipe existing content.
+DELETE FROM fts.content;
+
+-- Populate from all three sources in one INSERT (monotonic row_number
+-- across the union gives a clean, gap-free PK).
+INSERT INTO fts.content
+WITH all_rows AS (
+    -- Markdown sections
+    SELECT
+        file_path,
+        start_line,
+        end_line,
+        'markdown'::VARCHAR     AS extractor,
+        'doc_section'::VARCHAR  AS kind,
+        title                   AS name,
+        CAST(level AS INTEGER)  AS ordinal,
+        json_object(
+            'section_id',   section_id,
+            'section_path', section_path,
+            'level',        level
+        )                       AS attrs,
+        COALESCE(title, '') || chr(10) || COALESCE(content, '') AS text
+    FROM read_markdown_sections(
+        resolve(getvariable('fts_docs_glob')),
+        include_content := true,
+        include_filepath := true
+    )
+    WHERE (title IS NOT NULL AND title != '')
+       OR (content IS NOT NULL AND content != '')
+
+    UNION ALL
+
+    -- Code definitions (functions, classes, modules) — high-signal named nodes
+    SELECT
+        file_path,
+        start_line,
+        end_line,
+        'sitting_duck'::VARCHAR AS extractor,
+        'definition'::VARCHAR   AS kind,
+        name,
+        CAST(node_id AS INTEGER) AS ordinal,
+        json_object(
+            'semantic_type', semantic_type_to_string(semantic_type),
+            'depth',         depth,
+            'parent_id',     parent_id
+        )                       AS attrs,
+        COALESCE(name, '') || ' ' || COALESCE(peek, '') AS text
+    FROM read_ast(resolve(getvariable('fts_code_glob')))
+    WHERE name IS NOT NULL
+      AND name != ''
+      AND (is_function_definition(semantic_type)
+        OR is_class_definition(semantic_type)
+        OR is_module_definition(semantic_type))
+
+    UNION ALL
+
+    -- Code comments — tree-sitter comment nodes only (not docstrings,
+    -- which are string literals in Python). See 'string' branch below.
+    SELECT
+        file_path,
+        start_line,
+        end_line,
+        'sitting_duck'::VARCHAR AS extractor,
+        'comment'::VARCHAR      AS kind,
+        NULL                    AS name,
+        CAST(node_id AS INTEGER) AS ordinal,
+        json_object(
+            'semantic_type', semantic_type_to_string(semantic_type),
+            'depth',         depth,
+            'parent_id',     parent_id
+        )                       AS attrs,
+        peek                    AS text
+    FROM read_ast(resolve(getvariable('fts_code_glob')))
+    WHERE is_comment(semantic_type)
+      AND peek IS NOT NULL
+      AND peek != ''
+
+    UNION ALL
+
+    -- Code string literals — includes Python docstrings (which tree-sitter
+    -- classifies as string nodes, not comment nodes), URLs, SQL queries,
+    -- error messages, etc. Length filter (>= 8) trims trivial noise like
+    -- 'x', '/', single-char constants; meaningful short strings like 'auth'
+    -- are covered by definition names already.
+    --
+    -- is_string_literal matches both the outer string node ("foo") and the
+    -- inner string_content (foo). QUALIFY keeps the longest peek per
+    -- (file, line span), which is the outer — preserves quoting context
+    -- and avoids duplicate hits for the same literal.
+    SELECT
+        file_path,
+        start_line,
+        end_line,
+        'sitting_duck'::VARCHAR AS extractor,
+        'string'::VARCHAR       AS kind,
+        NULL                    AS name,
+        CAST(node_id AS INTEGER) AS ordinal,
+        json_object(
+            'semantic_type', semantic_type_to_string(semantic_type),
+            'depth',         depth,
+            'parent_id',     parent_id
+        )                       AS attrs,
+        peek                    AS text
+    FROM read_ast(resolve(getvariable('fts_code_glob')))
+    WHERE is_string_literal(semantic_type)
+      AND peek IS NOT NULL
+      AND length(peek) >= 8
+    QUALIFY row_number() OVER (
+        PARTITION BY file_path, start_line, end_line
+        ORDER BY length(peek) DESC
+    ) = 1
+)
+SELECT
+    row_number() OVER () AS id,
+    file_path,
+    start_line,
+    end_line,
+    extractor,
+    kind,
+    name,
+    ordinal,
+    attrs,
+    text
+FROM all_rows;
+
+-- (Re)create BM25 index. overwrite = 1 replaces any existing index
+-- with the same target, so this works for both first-build and rebuild.
+PRAGMA create_fts_index('fts.content', 'id', 'text', overwrite = 1);

--- a/sql/tools/fts.sql
+++ b/sql/tools/fts.sql
@@ -1,0 +1,71 @@
+-- Fledgling: FTS Tool Publications
+--
+-- MCP tool publications for full-text search. Wraps macros from
+-- sql/fts.sql. Rebuild is not exposed as an MCP tool — it lives in
+-- sql/fts_rebuild.sql and is triggered by the CLI or a Python helper.
+
+SELECT mcp_publish_tool(
+    'SearchContent',
+    'BM25 full-text search across all indexed content (markdown sections, code definitions, code comments, code string literals). Requires a populated FTS index — call the rebuild script first. Optional filters: kind (doc_section/definition/comment/string), extractor (markdown/sitting_duck).',
+    'SELECT file_path || '':'' || start_line || ''-'' || end_line AS location,
+            extractor, kind, name, score, text
+     FROM search_content(
+         $query,
+         filter_kind := NULLIF($kind, ''null''),
+         filter_extractor := NULLIF($extractor, ''null''),
+         limit_n := COALESCE(TRY_CAST(NULLIF($limit, ''null'') AS INT), 20)
+     )',
+    '{
+        "query": {"type": "string", "description": "BM25 search query"},
+        "kind": {"type": "string", "description": "Filter by kind: doc_section, definition, comment, or string"},
+        "extractor": {"type": "string", "description": "Filter by extractor: markdown or sitting_duck"},
+        "limit": {"type": "integer", "description": "Max rows (default 20)"}
+    }',
+    '["query"]',
+    'markdown'
+);
+
+SELECT mcp_publish_tool(
+    'SearchDocs',
+    'BM25 search over markdown documentation sections. Requires a populated FTS index.',
+    'SELECT file_path || '':'' || start_line || ''-'' || end_line AS location,
+            name AS heading, score, text
+     FROM search_docs(
+         $query,
+         limit_n := COALESCE(TRY_CAST(NULLIF($limit, ''null'') AS INT), 20)
+     )',
+    '{
+        "query": {"type": "string", "description": "BM25 search query"},
+        "limit": {"type": "integer", "description": "Max rows (default 20)"}
+    }',
+    '["query"]',
+    'markdown'
+);
+
+SELECT mcp_publish_tool(
+    'SearchCode',
+    'BM25 search over code (definitions, comments, string literals including docstrings). Requires a populated FTS index. Optional kind filter: definition, comment, or string.',
+    'SELECT file_path || '':'' || start_line || ''-'' || end_line AS location,
+            kind, name, score, text
+     FROM search_code(
+         $query,
+         filter_kind := NULLIF($kind, ''null''),
+         limit_n := COALESCE(TRY_CAST(NULLIF($limit, ''null'') AS INT), 20)
+     )',
+    '{
+        "query": {"type": "string", "description": "BM25 search query"},
+        "kind": {"type": "string", "description": "Filter by code kind: definition, comment, or string"},
+        "limit": {"type": "integer", "description": "Max rows (default 20)"}
+    }',
+    '["query"]',
+    'markdown'
+);
+
+SELECT mcp_publish_tool(
+    'FtsStats',
+    'Counts per extractor/kind of what is currently in the FTS index. Useful for checking whether the index is populated before searching.',
+    'SELECT * FROM fts_stats()',
+    '{}',
+    '[]',
+    'markdown'
+);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,6 +148,42 @@ def structural_macros(con):
 
 
 @pytest.fixture
+def fts_macros(con):
+    """Connection with FTS extension + sandbox + fts macros (schema + search).
+
+    Does NOT populate the index — use `fts_populated` for search tests.
+    """
+    con.execute("LOAD read_lines")
+    con.execute("LOAD sitting_duck")
+    con.execute("LOAD markdown")
+    con.execute("LOAD fts")
+    con.execute(f"SET VARIABLE session_root = '{PROJECT_ROOT}'")
+    load_sql(con, "sandbox.sql")
+    load_sql(con, "fts.sql")
+    return con
+
+
+@pytest.fixture(scope="session")
+def fts_populated():
+    """Session-scoped FTS connection with the repo rebuilt into the index.
+
+    Building the index is expensive (~3s against the repo). Session scope
+    lets read-only search tests share one populated connection.
+    """
+    con = duckdb.connect(":memory:")
+    con.execute("LOAD read_lines")
+    con.execute("LOAD sitting_duck")
+    con.execute("LOAD markdown")
+    con.execute("LOAD fts")
+    con.execute(f"SET VARIABLE session_root = '{PROJECT_ROOT}'")
+    load_sql(con, "sandbox.sql")
+    load_sql(con, "fts.sql")
+    load_sql(con, "fts_rebuild.sql")
+    yield con
+    con.close()
+
+
+@pytest.fixture
 def workflows_macros(con):
     """Connection with all extensions + every tier needed for workflow composition."""
     con.execute("LOAD read_lines")

--- a/tests/test_fts.py
+++ b/tests/test_fts.py
@@ -1,0 +1,222 @@
+"""Tests for full-text search macros (fts tier)."""
+
+import pytest
+from conftest import PROJECT_ROOT, load_sql
+
+
+# ── Rebuild / ingestion ──────────────────────────────────────────────
+
+
+class TestFtsRebuild:
+    def test_populates_content(self, fts_populated):
+        count = fts_populated.execute(
+            "SELECT count(*) FROM fts.content"
+        ).fetchone()[0]
+        assert count > 1000  # repo has thousands of indexed chunks
+
+    def test_all_kinds_present(self, fts_populated):
+        kinds = fts_populated.execute(
+            "SELECT DISTINCT kind FROM fts.content"
+        ).fetchall()
+        assert set(k[0] for k in kinds) == {
+            "doc_section", "definition", "comment", "string",
+        }
+
+    def test_both_extractors_present(self, fts_populated):
+        extractors = fts_populated.execute(
+            "SELECT DISTINCT extractor FROM fts.content"
+        ).fetchall()
+        assert set(e[0] for e in extractors) == {"markdown", "sitting_duck"}
+
+    def test_row_ids_unique(self, fts_populated):
+        total, unique = fts_populated.execute(
+            "SELECT count(*), count(DISTINCT id) FROM fts.content"
+        ).fetchone()
+        assert total == unique
+
+    def test_markdown_rows_have_heading(self, fts_populated):
+        # Every doc_section row should have a non-empty title in `name`.
+        missing = fts_populated.execute(
+            "SELECT count(*) FROM fts.content "
+            "WHERE extractor = 'markdown' AND (name IS NULL OR name = '')"
+        ).fetchone()[0]
+        # Allow a handful of edge cases (frontmatter-only, etc.) but not many.
+        assert missing < 5
+
+    def test_code_definitions_have_names(self, fts_populated):
+        missing = fts_populated.execute(
+            "SELECT count(*) FROM fts.content "
+            "WHERE kind = 'definition' AND (name IS NULL OR name = '')"
+        ).fetchone()[0]
+        assert missing == 0
+
+    def test_rebuild_is_idempotent(self, fts_macros):
+        load_sql(fts_macros, "fts_rebuild.sql")
+        count1 = fts_macros.execute(
+            "SELECT count(*) FROM fts.content"
+        ).fetchone()[0]
+        load_sql(fts_macros, "fts_rebuild.sql")
+        count2 = fts_macros.execute(
+            "SELECT count(*) FROM fts.content"
+        ).fetchone()[0]
+        assert count1 == count2
+        assert count1 > 0
+
+
+# ── fts_stats ────────────────────────────────────────────────────────
+
+
+class TestFtsStats:
+    def test_returns_rows(self, fts_populated):
+        rows = fts_populated.execute("SELECT * FROM fts_stats()").fetchall()
+        assert len(rows) == 4  # one per (extractor, kind) combo
+
+    def test_columns(self, fts_populated):
+        desc = fts_populated.execute(
+            "DESCRIBE SELECT * FROM fts_stats()"
+        ).fetchall()
+        col_names = [r[0] for r in desc]
+        assert col_names == ["extractor", "kind", "row_count", "file_count"]
+
+    def test_counts_are_positive(self, fts_populated):
+        rows = fts_populated.execute(
+            "SELECT row_count, file_count FROM fts_stats()"
+        ).fetchall()
+        for row_count, file_count in rows:
+            assert row_count > 0
+            assert file_count > 0
+
+
+# ── search_content (unified) ─────────────────────────────────────────
+
+
+class TestSearchContent:
+    def test_returns_matches_for_common_term(self, fts_populated):
+        rows = fts_populated.execute(
+            "SELECT * FROM search_content('lockdown')"
+        ).fetchall()
+        assert len(rows) > 0
+
+    def test_ordered_by_score_desc(self, fts_populated):
+        scores = fts_populated.execute(
+            "SELECT score FROM search_content('connection')"
+        ).fetchall()
+        score_vals = [r[0] for r in scores]
+        assert score_vals == sorted(score_vals, reverse=True)
+
+    def test_filter_by_kind_doc_section(self, fts_populated):
+        kinds = fts_populated.execute(
+            "SELECT DISTINCT kind FROM search_content("
+            "'sandbox', filter_kind := 'doc_section')"
+        ).fetchall()
+        assert [k[0] for k in kinds] == ["doc_section"]
+
+    def test_filter_by_kind_definition(self, fts_populated):
+        kinds = fts_populated.execute(
+            "SELECT DISTINCT kind FROM search_content("
+            "'lockdown', filter_kind := 'definition')"
+        ).fetchall()
+        assert [k[0] for k in kinds] == ["definition"]
+
+    def test_filter_by_extractor_markdown(self, fts_populated):
+        extractors = fts_populated.execute(
+            "SELECT DISTINCT extractor FROM search_content("
+            "'docs', filter_extractor := 'markdown')"
+        ).fetchall()
+        assert [e[0] for e in extractors] == ["markdown"]
+
+    def test_filter_by_extractor_sitting_duck(self, fts_populated):
+        extractors = fts_populated.execute(
+            "SELECT DISTINCT extractor FROM search_content("
+            "'connect', filter_extractor := 'sitting_duck')"
+        ).fetchall()
+        assert [e[0] for e in extractors] == ["sitting_duck"]
+
+    def test_limit_respected(self, fts_populated):
+        rows = fts_populated.execute(
+            "SELECT * FROM search_content('test', limit_n := 5)"
+        ).fetchall()
+        assert len(rows) <= 5
+
+    def test_no_query_match_returns_empty(self, fts_populated):
+        # Compute the term at runtime so the literal doesn't appear in any
+        # indexed source file. A static string here would match itself —
+        # this test file gets indexed by the session fixture.
+        fake = "q" * 25
+        rows = fts_populated.execute(
+            "SELECT * FROM search_content(?)", [fake]
+        ).fetchall()
+        assert rows == []
+
+    def test_score_column_present(self, fts_populated):
+        desc = fts_populated.execute(
+            "DESCRIBE SELECT * FROM search_content('test')"
+        ).fetchall()
+        col_names = [r[0] for r in desc]
+        assert "score" in col_names
+        assert "text" in col_names
+        assert "file_path" in col_names
+
+
+# ── search_docs ──────────────────────────────────────────────────────
+
+
+class TestSearchDocs:
+    def test_returns_only_doc_sections(self, fts_populated):
+        # search_docs is a thin wrapper that pins kind='doc_section'.
+        # The kind column isn't in the result shape, so assert the content
+        # rows all come from markdown extractor via join back.
+        rows = fts_populated.execute(
+            "SELECT c.extractor, c.kind "
+            "FROM search_docs('sandbox') s "
+            "JOIN fts.content c ON c.id = s.id"
+        ).fetchall()
+        assert len(rows) > 0
+        assert all(e == "markdown" and k == "doc_section" for e, k in rows)
+
+    def test_limit_respected(self, fts_populated):
+        rows = fts_populated.execute(
+            "SELECT * FROM search_docs('connection', 5)"
+        ).fetchall()
+        assert len(rows) <= 5
+
+
+# ── search_code ──────────────────────────────────────────────────────
+
+
+class TestSearchCode:
+    def test_returns_only_code_rows(self, fts_populated):
+        rows = fts_populated.execute(
+            "SELECT DISTINCT extractor FROM search_code('connection')"
+        ).fetchall()
+        assert [r[0] for r in rows] == ["sitting_duck"]
+
+    def test_filter_kind_definition(self, fts_populated):
+        rows = fts_populated.execute(
+            "SELECT DISTINCT kind FROM search_code("
+            "'connect', filter_kind := 'definition')"
+        ).fetchall()
+        assert [r[0] for r in rows] == ["definition"]
+
+    def test_filter_kind_comment(self, fts_populated):
+        rows = fts_populated.execute(
+            "SELECT DISTINCT kind FROM search_code("
+            "'workaround', filter_kind := 'comment')"
+        ).fetchall()
+        # Only comments matched, or no matches (if no comments mention the term).
+        assert rows == [] or [r[0] for r in rows] == ["comment"]
+
+    def test_filter_kind_string(self, fts_populated):
+        rows = fts_populated.execute(
+            "SELECT DISTINCT kind FROM search_code("
+            "'SELECT FROM read_ast', filter_kind := 'string')"
+        ).fetchall()
+        assert [r[0] for r in rows] == ["string"]
+
+    def test_without_kind_returns_multiple_kinds(self, fts_populated):
+        # 'auth' is common enough to appear in multiple code kinds.
+        rows = fts_populated.execute(
+            "SELECT DISTINCT kind FROM search_code('test connection')"
+        ).fetchall()
+        kinds = set(r[0] for r in rows)
+        assert kinds.issubset({"definition", "comment", "string"})

--- a/tests/test_fts.py
+++ b/tests/test_fts.py
@@ -220,3 +220,56 @@ class TestSearchCode:
         ).fetchall()
         kinds = set(r[0] for r in rows)
         assert kinds.issubset({"definition", "comment", "string"})
+
+
+# ── find_code_ranked (structural + FTS composition) ──────────────────
+
+
+class TestFindCodeRanked:
+    # ast_select resolves globs against cwd (not session_root), so tests
+    # pin absolute file patterns via PROJECT_ROOT.
+    PY_GLOB = PROJECT_ROOT + "/**/*.py"
+
+    def test_returns_matches_for_func_selector(self, fts_populated):
+        rows = fts_populated.execute(
+            "SELECT * FROM find_code_ranked(?, ?, ?)",
+            [self.PY_GLOB, ".func", "function_callers"],
+        ).fetchall()
+        assert len(rows) > 0
+
+    def test_ordered_by_score_desc(self, fts_populated):
+        scores = fts_populated.execute(
+            "SELECT score FROM find_code_ranked(?, ?, ?)",
+            [self.PY_GLOB, ".func", "function_callers"],
+        ).fetchall()
+        vals = [s[0] for s in scores]
+        assert vals == sorted(vals, reverse=True)
+
+    def test_restricts_to_class_kind_for_class_selector(self, fts_populated):
+        # .class should only yield class definitions, not plain functions.
+        kinds = fts_populated.execute(
+            "SELECT DISTINCT kind FROM find_code_ranked(?, ?, ?)",
+            [self.PY_GLOB, ".class", "Connection"],
+        ).fetchall()
+        for (k,) in kinds:
+            assert "class" in k.lower()
+
+    def test_no_match_returns_empty(self, fts_populated):
+        # Literal computed at runtime to avoid self-indexing.
+        fake = "q" * 25
+        rows = fts_populated.execute(
+            "SELECT * FROM find_code_ranked(?, ?, ?)",
+            [self.PY_GLOB, ".func", fake],
+        ).fetchall()
+        assert rows == []
+
+    def test_columns(self, fts_populated):
+        desc = fts_populated.execute(
+            "DESCRIBE SELECT * FROM find_code_ranked(?, ?, ?)",
+            [self.PY_GLOB, ".func", "connect"],
+        ).fetchall()
+        cols = [r[0] for r in desc]
+        assert "file_path" in cols
+        assert "name" in cols
+        assert "kind" in cols
+        assert "score" in cols


### PR DESCRIPTION
## Summary

Adds a new **fts** tier backed by DuckDB's bundled [fts extension](https://duckdb.org/docs/current/core_extensions/full_text_search). BM25-based lexical search across markdown documentation and code (definitions, comments, and string literals) — the lexical counterpart to our existing structural AST search.

- New MCP tools: **SearchContent**, **SearchDocs**, **SearchCode**, **FtsStats**
- New Python API: `Connection.rebuild_fts(docs_glob=..., code_glob=...)`
- One table (`fts.content`) holds all indexed chunks; extractor/kind discriminate
- 26 new tests, all passing

## Design

Per-extractor conventions, not a hard schema:

| column | purpose |
|---|---|
| `extractor` | `'markdown'` or `'sitting_duck'` |
| `kind` | `'doc_section'` / `'definition'` / `'comment'` / `'string'` |
| `name`, `ordinal`, `attrs` | extractor-defined (opaque) |
| `text` | BM25 target |

Adding a new extractor (conversations, SQL macros, etc.) is an INSERT path, not a schema change.

Storage location is **caller-controlled**: schema lives in the current database. In-memory → ephemeral index; persistent DB → persistent index. Fledgling doesn't pick a path.

## Timings (this repo, ~70 files, ~6k chunks, DuckDB 1.5.1)

| Operation | Time |
|---|---|
| `fledgling.connect()` (cold) | ~6.3 s |
| `rebuild_fts()` (full corpus) | ~2.7 s |
| `search_content('lockdown')` | ~25 ms |
| `search_code('function_callers', filter_kind := 'definition')` | ~23 ms |

Index stats after rebuild:

```
 extractor     | kind        | rows  | files
---------------+-------------+-------+------
 markdown      | doc_section |   989 |    72
 sitting_duck  | comment     |   589 |    56
 sitting_duck  | definition  |  1408 |    60
 sitting_duck  | string      |  3225 |    64
```

## Known limitations (all called out in `docs/macros/fts.md`)

- **Manual rebuild.** The FTS index doesn't auto-update on source changes — this is a DuckDB upstream limitation ([duckdb#3543](https://github.com/duckdb/duckdb/issues/3543)). Call `rebuild_fts()` after edits.
- **Stub index at init.** `sql/fts.sql` runs `PRAGMA create_fts_index(..., overwrite = 1)` on the empty table so the search macros can reference `fts_fts_content.match_bm25` at definition time. On a persistent DB with an already-populated index, reconnecting wipes the index — rebuild after reconnect. Easy to add a Python guard later if this becomes painful.
- **String dedup.** Tree-sitter reports nested string nodes (outer literal + `string_content`). `QUALIFY row_number() OVER (PARTITION BY file, lines ORDER BY length(peek) DESC) = 1` keeps the outer form.

## Files

- `sql/fts.sql` — schema + `fts.content` table + search macros + stub index
- `sql/fts_rebuild.sql` — parameterized full-rebuild script
- `sql/tools/fts.sql` — 4 MCP tool publications
- `fledgling/connection.py` — `'fts'` added to defaults; `rebuild_fts()` method
- `init/init-fledgling-base.sql` — `LOAD fts`, module list, reads
- `tests/conftest.py` — `fts_macros` + session-scoped `fts_populated` fixtures
- `tests/test_fts.py` — 26 tests
- `docs/macros/fts.md` — tier doc with realistic examples and caveats
- `docs/index.md`, `SKILL.md` — tool list updates (20 → 24)

## Test plan

- [x] `tests/test_fts.py` passes (26/26)
- [x] Existing tests still pass (355 non-pro tests, 3 pre-existing `investigate_query` failures confirmed unrelated via `git stash`)
- [x] End-to-end Python API smoke test: `fledgling.connect(); con.rebuild_fts(); con.search_code(...)`
- [ ] Not yet tested: MCP tool invocation via `_create_mcp_server` (would extend `test_mcp_server.py`)
- [ ] Not yet tested: persistent-DB rebuild semantics (noted as caveat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)