### PR TITLE
feat: vendor/submodule-aware project discovery (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,29 @@
-## 0.11.1
+## 0.12.0
+
+### Added — vendor/submodule-aware project discovery (#47)
+`project_overview` and the new `source_files` macro now exclude dependency,
+build, cache, and third-party trees by default, so discovery reflects a
+project's own code instead of drowning in its vendored deps. On a DuckDB
+extension with `duckdb/` + `rdkit/` git submodules, `project_overview` dropped
+from **21,916 files to 71**; a `**/*.cpp` listing from **3,296 to 12**.
+
+- `_is_vendored_path(file_path)` — scalar predicate; the single source of truth
+  for "what to ignore". A path denylist (`.venv`, `node_modules`, `build`,
+  `dist`, `CMakeFiles`, `*-prefix`, `__pycache__`, caches, …) **plus** checked-in
+  third-party conventions (`vendor`, `third_party`, `External`, `googletest`)
+  that git-awareness alone can't distinguish.
+- `_submodule_prefixes(root)` — the git-aware half: parses `root/.gitmodules` to
+  exclude submodule trees, whose directory names are arbitrary (`duckdb/`,
+  `rdkit/`) and which no denylist could catch. Reads via
+  `read_lines(..., ignore_errors := true)`, so a missing `.gitmodules` (no
+  submodules, or not a git repo) yields no rows rather than an IO error.
+- `source_files(root, pattern := '**/*', include_ignored := false)` — the
+  filtered discovery surface: `glob` minus `_is_vendored_path` minus
+  `_submodule_prefixes`. Glob-based, so brand-new **uncommitted** files are still
+  surfaced (unlike a pure git-tracked listing) and it works in non-git dirs.
+- `project_overview(root, include_ignored := false)` — gains the same filtering
+  (via `source_files`) plus an `include_ignored := true` opt-out that restores
+  the old count-everything behavior.
 
 ### Fixed
 - **Pin `duckdb==1.5.2`.** The unbounded `duckdb>=1.5.0` let a fresh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fledgling-mcp"
-version = "0.11.1"
+version = "0.12.0"
 description = "MCP tools that help AI agents get their bearings in a codebase — unified SQL views over code, git, docs, and conversations, powered by DuckDB."
 readme = "README.md"
 license = "Apache-2.0"

--- a/sql/source.sql
+++ b/sql/source.sql
@@ -118,15 +118,93 @@ CREATE OR REPLACE MACRO list_files(pattern, commit := NULL) AS TABLE
         END
     );
 
+-- _is_vendored_path: TRUE when a path lives in a dependency, build, cache, VCS,
+-- or checked-in third-party tree that should be excluded from project
+-- discovery. Used by source_files / project_overview (and reused by squackit's
+-- AST tools) so the "what to ignore" policy has a single home in fledgling.
+-- Pattern-based, so it catches checked-in vendored trees (googletest,
+-- third_party, vendor) that git-awareness alone misses. Submodules are handled
+-- separately by _submodule_prefixes since their directory names are arbitrary.
+CREATE OR REPLACE MACRO _is_vendored_path(file_path) AS (
+       file_path LIKE '%/.git/%'
+    OR file_path LIKE '%/.svn/%'
+    OR file_path LIKE '%/.hg/%'
+    OR file_path LIKE '%/.venv/%'
+    OR file_path LIKE '%/venv/%'
+    OR file_path LIKE '%/node_modules/%'
+    OR file_path LIKE '%/bower_components/%'
+    OR file_path LIKE '%/__pycache__/%'
+    OR file_path LIKE '%/.mypy_cache/%'
+    OR file_path LIKE '%/.pytest_cache/%'
+    OR file_path LIKE '%/.ruff_cache/%'
+    OR file_path LIKE '%/.tox/%'
+    OR file_path LIKE '%/.idea/%'
+    OR file_path LIKE '%/.vscode/%'
+    OR file_path LIKE '%/dist/%'
+    OR file_path LIKE '%/build/%'
+    OR file_path LIKE '%/_build/%'
+    OR file_path LIKE '%/cmake-build-%/%'
+    OR file_path LIKE '%/CMakeFiles/%'
+    OR file_path LIKE '%-prefix/%'
+    OR file_path LIKE '%/.eggs/%'
+    OR file_path LIKE '%.egg-info/%'
+    -- checked-in third-party / vendored trees (not git-distinguishable)
+    OR file_path LIKE '%/vendor/%'
+    OR file_path LIKE '%/third_party/%'
+    OR file_path LIKE '%/third-party/%'
+    OR file_path LIKE '%/External/%'
+    OR file_path LIKE '%/googletest%'
+);
+
+-- _submodule_prefixes: directory prefixes (root-absolute, trailing slash) of any
+-- git submodules declared in root/.gitmodules. Empty when there are no submodules
+-- or the directory is not a git repo — read_lines(..., ignore_errors := true)
+-- yields no rows instead of an IO error on a missing .gitmodules. This is the
+-- git-aware half of the ignore policy: submodule contents are not gitignored and
+-- carry arbitrary names (e.g. duckdb/, rdkit/), so only .gitmodules identifies them.
+--
+-- Examples:
+--   SELECT * FROM _submodule_prefixes('/path/to/repo');
+CREATE OR REPLACE MACRO _submodule_prefixes(root := '.') AS TABLE
+    SELECT DISTINCT rtrim(root, '/') || '/' ||
+           trim(regexp_extract(content, 'path[ \t]*=[ \t]*(\S.*)', 1)) || '/' AS prefix
+    FROM read_lines(rtrim(root, '/') || '/.gitmodules', ignore_errors := true)
+    WHERE regexp_matches(content, 'path[ \t]*=[ \t]*\S');
+
+-- source_files: List a project's own source files, excluding vendored, build,
+-- cache, and submodule trees. This is the filtered discovery surface — prefer it
+-- over raw list_files/glob when you want "the project's code" rather than
+-- "every file on disk". Combines a pattern denylist (_is_vendored_path) with
+-- git-submodule exclusion (_submodule_prefixes). Pass include_ignored := true to
+-- get the unfiltered glob (the same set as list_files).
+--
+-- Examples:
+--   SELECT * FROM source_files('.');
+--   SELECT * FROM source_files('/path/to/repo', '**/*.py');
+--   SELECT * FROM source_files('.', '**/*', include_ignored := true);
+CREATE OR REPLACE MACRO source_files(root := '.', pattern := '**/*', include_ignored := false) AS TABLE
+    SELECT file AS file_path
+    FROM glob(rtrim(root, '/') || '/' || pattern)
+    WHERE include_ignored
+       OR (NOT _is_vendored_path(file)
+           AND NOT EXISTS (
+               SELECT 1 FROM _submodule_prefixes(root) s
+               WHERE file LIKE s.prefix || '%'
+           ))
+    ORDER BY file_path;
+
 -- project_overview: Summarize project contents by file type.
 -- Groups files by extension and maps to language names, giving a quick
--- overview of what a project contains. Filters out .git, .venv,
--- node_modules, __pycache__, and other dependency/build directories.
+-- overview of what a project contains. By default excludes vendored, build,
+-- cache, and git-submodule trees (via source_files) so the summary reflects
+-- the project's own code rather than its dependencies. Pass
+-- include_ignored := true to count everything on disk.
 --
 -- Examples:
 --   SELECT * FROM project_overview('/path/to/project');
 --   SELECT * FROM project_overview('.');
-CREATE OR REPLACE MACRO project_overview(root := '.') AS TABLE
+--   SELECT * FROM project_overview('.', include_ignored := true);
+CREATE OR REPLACE MACRO project_overview(root := '.', include_ignored := false) AS TABLE
     SELECT
         CASE extension
             WHEN 'py' THEN 'Python'
@@ -166,19 +244,7 @@ CREATE OR REPLACE MACRO project_overview(root := '.') AS TABLE
     FROM (
         SELECT
             lower(regexp_extract(file_path, '\.([^./]+)$', 1)) AS extension
-        FROM list_files(rtrim(root, '/') || '/**/*')
-        WHERE file_path NOT LIKE '%/.git/%'
-          AND file_path NOT LIKE '%/.venv/%'
-          AND file_path NOT LIKE '%/venv/%'
-          AND file_path NOT LIKE '%/node_modules/%'
-          AND file_path NOT LIKE '%/__pycache__/%'
-          AND file_path NOT LIKE '%/.mypy_cache/%'
-          AND file_path NOT LIKE '%/.pytest_cache/%'
-          AND file_path NOT LIKE '%/.tox/%'
-          AND file_path NOT LIKE '%/dist/%'
-          AND file_path NOT LIKE '%/build/%'
-          AND file_path NOT LIKE '%/.eggs/%'
-          AND file_path NOT LIKE '%/*.egg-info/%'
+        FROM source_files(root, '**/*', include_ignored := include_ignored)
     )
     GROUP BY ALL
     ORDER BY file_count DESC;

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -183,6 +183,109 @@ class TestProjectOverviewMacro:
         ).fetchall()
         assert len(rows) == 0
 
+    def test_excludes_vendored_and_build_dirs(self, source_macros, tmp_path):
+        # Own code plus dependency / build / checked-in vendored trees that
+        # project_overview must not count.
+        (tmp_path / "main.py").write_text("print('hi')")
+        for junk in [
+            "node_modules/dep/index.js",
+            "build/main.o.py",
+            "__pycache__/main.cpython.py",
+            "test/googletest-release-1.8.0/src/gtest.cc",
+            "third_party/lib/lib.py",
+        ]:
+            p = tmp_path / junk
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("x")
+        rows = source_macros.execute(
+            "SELECT * FROM project_overview(?)", [str(tmp_path)]
+        ).fetchall()
+        by_lang = {r[0]: r[2] for r in rows}
+        # Only the one own Python file survives; no JS / C++ from vendored trees.
+        assert by_lang.get("Python") == 1
+        assert "JavaScript" not in by_lang
+        assert "C++" not in by_lang
+
+    def test_include_ignored_restores_everything(self, source_macros, tmp_path):
+        (tmp_path / "main.py").write_text("print('hi')")
+        (tmp_path / "node_modules" / "dep").mkdir(parents=True)
+        (tmp_path / "node_modules" / "dep" / "index.js").write_text("x")
+        filtered = source_macros.execute(
+            "SELECT sum(file_count) FROM project_overview(?)", [str(tmp_path)]
+        ).fetchone()[0]
+        unfiltered = source_macros.execute(
+            "SELECT sum(file_count) FROM project_overview(?, include_ignored := true)",
+            [str(tmp_path)],
+        ).fetchone()[0]
+        assert filtered == 1
+        assert unfiltered == 2
+
+
+class TestSourceFilesMacro:
+    def test_filters_vendored(self, source_macros, tmp_path):
+        (tmp_path / "app.py").write_text("x")
+        (tmp_path / "vendor" / "pkg").mkdir(parents=True)
+        (tmp_path / "vendor" / "pkg" / "v.py").write_text("x")
+        rows = source_macros.execute(
+            "SELECT file_path FROM source_files(?, '**/*.py')", [str(tmp_path)]
+        ).fetchall()
+        paths = {r[0] for r in rows}
+        assert any(p.endswith("/app.py") for p in paths)
+        assert not any("/vendor/" in p for p in paths)
+
+    def test_include_ignored_passthrough(self, source_macros, tmp_path):
+        (tmp_path / "app.py").write_text("x")
+        (tmp_path / "build").mkdir()
+        (tmp_path / "build" / "out.py").write_text("x")
+        filtered = source_macros.execute(
+            "SELECT count(*) FROM source_files(?, '**/*.py')", [str(tmp_path)]
+        ).fetchone()[0]
+        full = source_macros.execute(
+            "SELECT count(*) FROM source_files(?, '**/*.py', include_ignored := true)",
+            [str(tmp_path)],
+        ).fetchone()[0]
+        assert filtered == 1
+        assert full == 2
+
+    def test_excludes_git_submodule_contents(self, source_macros, tmp_path):
+        # A .gitmodules declaring a submodule dir whose (arbitrary) name no
+        # denylist could catch — only _submodule_prefixes excludes it.
+        (tmp_path / "src.py").write_text("x")
+        (tmp_path / ".gitmodules").write_text(
+            '[submodule "libfoo"]\n\tpath = libfoo\n\turl = https://x/libfoo\n'
+        )
+        (tmp_path / "libfoo" / "deep").mkdir(parents=True)
+        (tmp_path / "libfoo" / "deep" / "vendored.py").write_text("x")
+        rows = source_macros.execute(
+            "SELECT file_path FROM source_files(?, '**/*.py')", [str(tmp_path)]
+        ).fetchall()
+        paths = {r[0] for r in rows}
+        assert any(p.endswith("/src.py") for p in paths)
+        assert not any("/libfoo/" in p for p in paths)
+
+    def test_no_gitmodules_is_graceful(self, source_macros, tmp_path):
+        # No .gitmodules -> read_lines(ignore_errors) yields no rows, not an error.
+        (tmp_path / "a.py").write_text("x")
+        rows = source_macros.execute(
+            "SELECT count(*) FROM source_files(?, '**/*.py')", [str(tmp_path)]
+        ).fetchone()
+        assert rows[0] == 1
+
+    def test_keeps_uncommitted_new_files(self, source_macros, tmp_path):
+        # source_files is glob-based, so brand-new (uncommitted, untracked) own
+        # files are still surfaced — unlike a pure git-tracked listing.
+        (tmp_path / ".gitmodules").write_text(
+            '[submodule "vend"]\n\tpath = vend\n\turl = https://x/vend\n'
+        )
+        (tmp_path / "vend").mkdir()
+        (tmp_path / "vend" / "dep.py").write_text("x")
+        (tmp_path / "brand_new.py").write_text("x")  # never committed
+        rows = source_macros.execute(
+            "SELECT file_path FROM source_files(?, '**/*.py')", [str(tmp_path)]
+        ).fetchall()
+        paths = {r[0] for r in rows}
+        assert any(p.endswith("/brand_new.py") for p in paths)
+
 
 class TestFileLineCount:
     def test_single_file(self, source_macros):


### PR DESCRIPTION
Closes #47.

De-floods fledgling's project discovery so it reflects a project's **own**
code instead of drowning in vendored dependencies, build output, and git
submodules.

## What

A single-source-of-truth ignore policy in `sql/source.sql`:

- **`_is_vendored_path(file_path)`** — scalar denylist predicate covering build
  dirs, caches, dependency dirs, and checked-in third-party conventions
  (`vendor`, `third_party`, `External`, `googletest`) that git-awareness alone
  can't distinguish.
- **`_submodule_prefixes(root)`** — the git-aware half: parses `root/.gitmodules`
  to exclude submodule trees, whose directory names are arbitrary (`duckdb/`,
  `rdkit/`) and which no denylist could catch. Reads via
  `read_lines(..., ignore_errors := true)`, so a missing `.gitmodules` yields no
  rows rather than an IO error (works in non-git dirs).
- **`source_files(root, pattern := '**/*', include_ignored := false)`** — the
  filtered discovery surface: `glob` minus both predicates. Glob-based, so
  brand-new uncommitted files are still surfaced (unlike a pure git-tracked list).
- **`project_overview`** — gains the same filtering plus `include_ignored := true`.

## Impact (ground truth)

| repo | surface | before | after |
|------|---------|-------:|------:|
| duckdb_rdkit (submodules) | `project_overview` | 21,916 | 71 |
| duckdb_rdkit | `**/*.cpp` listing | 3,296 | 12 |
| libgraphqlparser (checked-in googletest) | all files | 655 | 99 (0 googletest) |
| ghud (clean repo) | `**/*.py` | 31 | 31 (no false positives) |

## Behavior change

`project_overview` now **filters by default**. Callers that want the old
count-everything behavior pass `include_ignored := true`.

## Tests

+7 cases in `tests/test_source.py`: vendored/build exclusion, submodule
exclusion, `include_ignored` passthrough, missing-`.gitmodules` graceful, and
uncommitted-new files preserved. Full suite green (pre-existing CLI/MCP-catalog
failures are environment-only, present on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
